### PR TITLE
Revamp hero with media background and accent CTA buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,13 @@
     <a href="#contact">Contact</a>
   </nav>
 
-  <section id="home" class="hero glass fade-in">
+  <section id="home" class="hero fade-in">
+    <img class="hero-media" src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1920&q=80" alt="">
     <h1>The Project Archive</h1>
     <p class="tagline"></p>
     <div class="cta-group">
-      <a class="btn btn-outline" href="#services">View Portfolio</a>
-      <a class="btn btn-outline" href="#contact">Contact Me</a>
+      <a class="btn" href="#services">View Portfolio</a>
+      <a class="btn" href="#contact">Contact Me</a>
     </div>
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -117,23 +117,49 @@ img {
 }
 
  .hero {
+  position: relative;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
-  background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)),
-    url('https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1920&q=80')
-      center/cover no-repeat fixed;
- padding: 2rem;
+  overflow: hidden;
+  padding: 2rem;
   margin-bottom: 2rem;
-}
+  color: var(--bg-color);
+ }
 
-.hero h1 {
-  font-size: clamp(2.5rem, 8vw, 4rem);
+ .hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1;
+ }
+
+ .hero-media {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 0;
+ }
+
+ .hero h1,
+ .hero .tagline,
+ .hero .cta-group {
+  position: relative;
+  z-index: 2;
+ }
+
+ .hero h1 {
+  font-size: clamp(3rem, 10vw, 6rem);
   margin-bottom: 0.5rem;
-}
+  color: var(--accent-color);
+ }
 
 #typed-title {
   font: inherit;
@@ -151,26 +177,24 @@ img {
   justify-content: center;
 }
 
-.btn {
+ .btn {
   display: inline-block;
   padding: 0.75rem 1.5rem;
-  border-radius: 4px;
+  border: none;
+  border-radius: 50px;
   text-decoration: none;
+  background: var(--accent-color);
+  color: var(--bg-color);
   transition: background 0.3s ease, color 0.3s ease;
   cursor: pointer;
   font-weight: 700;
-}
+ }
 
-.btn-outline {
-  border: 2px solid var(--accent-color);
-  color: var(--text-color);
-}
-
-.btn-outline:hover,
-.btn-outline:focus {
-  background: var(--accent-color);
+ .btn:hover,
+ .btn:focus {
+  background: #ff553f;
   color: var(--bg-color);
-}
+ }
 
 .section {
   padding: 4rem 1.5rem;


### PR DESCRIPTION
## Summary
- add full-width hero image with semi-transparent tint overlay
- center hero text, enlarge h1 with accent color, and redesign CTA buttons

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a401d6935c832291aa88da79c6dbdd