### PR TITLE
style: add card layout and illustration to about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,9 +22,12 @@
     </nav>
   </header>
 
-  <main class="section glass fade-in">
-    <h1>About Us</h1>
-    <p>The Project Archive is a creative studio based in the Maldives, dedicated to capturing life’s most meaningful moments. Founded in 2024 from a passion for storytelling, we’ve since grown into a full-service studio transforming weddings, events, and everyday stories into timeless keepsakes. We don’t just document scenes; we capture the laughter between the poses, the tears during vows, the energy on the dance floor, and the quiet moments in between—preserving memories that last a lifetime.</p>
+  <main class="section fade-in">
+    <div class="info-card">
+      <img class="micro-illustration" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MCIgaGVpZ2h0PSI4MCIgdmlld0JveD0iMCAwIDgwIDgwIj4KICA8Y2lyY2xlIGN4PSI0MCIgY3k9IjQwIiByPSI0MCIgZmlsbD0iI2VmM2MyMyIvPgogIDxwYXRoIGQ9Ik00MCAxNUw0NyAzM0g2Nkw1MSA0NUw1OCA2M0w0MCA1MkwyMiA2M0wyOSA0NUwxNCAzM0gzM0w0MCAxNVoiIGZpbGw9IiNmZmZmZmYiLz4KPC9zdmc+Cg==" alt="" />
+      <h1><strong>About Us</strong><br><span class="secondary">Framing memories since 2024</span></h1>
+      <p>The Project Archive is a <strong>creative studio</strong> based in the <strong>Maldives</strong>, dedicated to capturing life’s most meaningful moments. Founded in <strong>2024</strong> from a passion for storytelling, we’ve since grown into a <strong>full-service studio</strong> transforming weddings, events, and everyday stories into timeless keepsakes. We don’t just document scenes; we capture the laughter between the poses, the tears during vows, the energy on the dance floor, and the quiet moments in between—preserving memories that last a lifetime.</p>
+    </div>
   </main>
 
   <footer class="footer"></footer>

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@
   --bg-color: rgba(246, 243, 232, 1);
   --panel-bg: rgba(255, 255, 255, 0.06);
   --panel-border: rgba(255, 255, 255, 0.18);
+  --bg-light: #ffffff;
 }
 
 * {
@@ -236,6 +237,43 @@ img {
 .section p {
   max-width: 800px;
   margin: 0 auto;
+}
+
+.info-card {
+  background: var(--bg-light);
+  border-radius: 24px;
+  padding: 2rem;
+  margin: 2rem auto;
+  position: relative;
+}
+
+.info-card h1 {
+  color: #666;
+  font-weight: 400;
+}
+
+.info-card h1 strong,
+.info-card strong {
+  color: #111;
+  font-weight: 700;
+}
+
+.info-card p {
+  color: #666;
+  margin-top: 1rem;
+}
+
+.secondary {
+  color: #999;
+}
+
+.micro-illustration {
+  position: absolute;
+  top: -20px;
+  right: -20px;
+  width: 80px;
+  height: 80px;
+  pointer-events: none;
 }
 
 .section.alt {


### PR DESCRIPTION
## Summary
- Wrap About page content in a padded card with light background and rounded corners
- Highlight key phrases with strong styling and add playful micro-illustration
- Introduce reusable `--bg-light` and card styles in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a401d72de083229a5380ce70b27d45