### PR TITLE
refactor: update colors and fonts

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,7 +6,7 @@
   <title>About - The Project Archive</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/approach.html
+++ b/approach.html
@@ -6,7 +6,7 @@
   <title>Approach - The Project Archive</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/contact.html
+++ b/contact.html
@@ -6,7 +6,7 @@
   <title>Contact - The Project Archive</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>The Project Archive</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/mission.html
+++ b/mission.html
@@ -6,7 +6,7 @@
   <title>Mission - The Project Archive</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/numbers.html
+++ b/numbers.html
@@ -6,7 +6,7 @@
   <title>In Numbers - The Project Archive</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/services.html
+++ b/services.html
@@ -6,7 +6,7 @@
   <title>Services - The Project Archive</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,9 @@
  :root {
-  --accent-color: #ef3c23; /* vibrant red */
-  --text-color: #333333;
-  --bg-color: rgba(246, 243, 232, 1);
+  --color-dark-text: #05192D;
+  --color-accent-blue: #2B60FF;
+  --color-accent-pink: #FF4175;
+  --color-accent-violet: #7928CA;
+  --bg-light: #F8F9FB;
   --panel-bg: rgba(255, 255, 255, 0.06);
   --panel-border: rgba(255, 255, 255, 0.18);
 }
@@ -21,19 +23,34 @@ section {
 }
 
 body {
-  font-family: 'Montserrat', system-ui, sans-serif;
+  font-family: 'Inter', system-ui, sans-serif;
   line-height: 1.6;
-  color: var(--text-color);
-  background-color: var(--bg-color);
+  font-weight: 400;
+  color: var(--color-dark-text);
+  background-color: var(--bg-light);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 700;
+}
+
+.nav a,
+.overlay-nav a {
+  font-weight: 500;
 }
 
 a {
-  color: var(--accent-color);
+  color: var(--color-accent-pink);
 }
 
 a:hover {
   text-decoration: underline;
-  color: var(--accent-color);
+  color: var(--color-accent-pink);
 }
 
 img {
@@ -55,7 +72,7 @@ img {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: rgba(246, 243, 232, 0.95);
+  background: var(--bg-light);
   backdrop-filter: blur(5px);
   opacity: 0;
   pointer-events: none;
@@ -69,7 +86,7 @@ img {
 }
 
 .overlay-nav a {
-  color: var(--text-color);
+  color: var(--color-dark-text);
   text-decoration: none;
   font-size: 2rem;
   line-height: 4rem;
@@ -79,7 +96,7 @@ img {
 .overlay-nav a:hover,
 .overlay-nav a:focus {
   text-decoration: underline;
-  text-decoration-color: var(--accent-color);
+  text-decoration-color: var(--color-accent-pink);
 }
 
 .hamburger {
@@ -100,7 +117,7 @@ img {
 .hamburger span {
   display: block;
   height: 2px;
-  background: var(--text-color);
+  background: var(--color-dark-text);
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
@@ -162,14 +179,14 @@ img {
 }
 
 .btn-outline {
-  border: 2px solid var(--accent-color);
-  color: var(--text-color);
+  border: 2px solid var(--color-accent-pink);
+  color: var(--color-dark-text);
 }
 
 .btn-outline:hover,
 .btn-outline:focus {
-  background: var(--accent-color);
-  color: var(--bg-color);
+  background: var(--color-accent-pink);
+  color: var(--bg-light);
 }
 
 .section {
@@ -199,7 +216,7 @@ img {
     right: 0;
     flex-direction: row;
     justify-content: flex-end;
-    background: rgba(246, 243, 232, 0.9);
+    background: var(--bg-light);
     backdrop-filter: blur(5px);
     opacity: 1;
     pointer-events: auto;
@@ -223,7 +240,7 @@ img {
   font-size: 2rem;
   margin: 0 auto 1rem;
   text-align: center;
-  border-bottom: 2px solid var(--accent-color);
+  border-bottom: 2px solid var(--color-accent-pink);
   display: inline-block;
   padding-bottom: 0.25rem;
 }
@@ -268,8 +285,8 @@ img {
 .stat-number {
   display: block;
   font-size: 3rem;
-  font-weight: 800;
-  color: var(--accent-color);
+  font-weight: 700;
+  color: var(--color-accent-pink);
 }
 
 .service {
@@ -279,7 +296,7 @@ img {
 .service h3 {
   font-size: 1.25rem;
   margin-bottom: 0.5rem;
-  color: var(--accent-color);
+  color: var(--color-accent-pink);
 }
 
 .service ul {
@@ -295,7 +312,7 @@ img {
 }
 
 .footer a {
-  color: var(--accent-color);
+  color: var(--color-accent-pink);
 }
 
 body {
@@ -367,7 +384,7 @@ body.loaded .fade-in {
   right: 1rem;
   background: none;
   border: none;
-  color: var(--text-color);
+  color: var(--color-dark-text);
   font-size: 2rem;
   cursor: pointer;
 }
@@ -412,8 +429,8 @@ body.loaded .fade-in {
   padding: 0.75rem;
   border: none;
   border-radius: 4px;
-  background-color: var(--accent-color);
-  color: var(--text-color);
+  background-color: var(--color-accent-pink);
+  color: var(--color-dark-text);
   font-weight: 700;
   cursor: pointer;
 }
@@ -430,8 +447,8 @@ body.loaded .fade-in {
   height: 3rem;
   border: none;
   border-radius: 50%;
-  background-color: var(--accent-color);
-  color: var(--text-color);
+  background-color: var(--color-accent-pink);
+  color: var(--color-dark-text);
   font-size: 1.5rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- switch to new Inter typography and adjust font weights
- refresh color variables for text, background, and accents
- update HTML pages to load Inter from Google Fonts

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a401d4b6ec8322a2b329dd9892924b