### PR TITLE
Add header logo and restyle overlay navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,14 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <button class="hamburger" aria-label="Open menu" aria-expanded="false">
-    <span></span>
-    <span></span>
-    <span></span>
-  </button>
+  <header class="site-header">
+    <a href="#home" class="logo">The Project Archive</a>
+    <button class="hamburger" aria-label="Open menu" aria-expanded="false">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+  </header>
   <nav class="overlay-nav" aria-hidden="true">
     <a href="#home">Home</a>
     <a href="#about">About</a>

--- a/script.js
+++ b/script.js
@@ -87,6 +87,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const hamburger = document.querySelector('.hamburger');
   const overlayNav = document.querySelector('.overlay-nav');
 
+  // hide overlay links by default
+  overlayNav.classList.remove('open');
+  overlayNav.setAttribute('aria-hidden', 'true');
+
   const mq = window.matchMedia('(min-width: 768px)');
   const handleNavVisibility = (e) => {
     if (e.matches) {

--- a/styles.css
+++ b/styles.css
@@ -42,15 +42,30 @@ img {
 }
 
 .site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 1rem 1.5rem;
-  max-width: 1000px;
-  margin: 0 auto;
+  z-index: 1100;
+}
+
+.logo {
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--text-color);
 }
 
 /* Overlay navigation */
+
 .overlay-nav {
   position: fixed;
   inset: 0;
+  width: 100vw;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -58,6 +73,7 @@ img {
   background: rgba(246, 243, 232, 0.95);
   backdrop-filter: blur(5px);
   opacity: 0;
+  visibility: hidden;
   pointer-events: none;
   transition: opacity 0.3s ease;
   z-index: 1000;
@@ -65,6 +81,7 @@ img {
 
 .overlay-nav.open {
   opacity: 1;
+  visibility: visible;
   pointer-events: auto;
 }
 
@@ -74,18 +91,15 @@ img {
   font-size: 2rem;
   line-height: 4rem;
   padding: 0.5rem 0;
+  font-weight: 700;
 }
 
 .overlay-nav a:hover,
 .overlay-nav a:focus {
-  text-decoration: underline;
-  text-decoration-color: var(--accent-color);
+  color: var(--accent-color);
 }
 
 .hamburger {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
   width: 2rem;
   height: 2rem;
   display: flex;
@@ -94,7 +108,7 @@ img {
   background: none;
   border: none;
   cursor: pointer;
-  z-index: 1100;
+  z-index: 1200;
 }
 
 .hamburger span {
@@ -202,6 +216,7 @@ img {
     background: rgba(246, 243, 232, 0.9);
     backdrop-filter: blur(5px);
     opacity: 1;
+    visibility: visible;
     pointer-events: auto;
     gap: 2rem;
     padding: 1rem 2rem;
@@ -212,6 +227,7 @@ img {
     font-size: 1rem;
     line-height: normal;
     padding: 0.5rem;
+    font-weight: 700;
   }
 
   .hamburger {


### PR DESCRIPTION
## Summary
- Add fixed site header with text logo and right-aligned hamburger menu
- Style overlay navigation to cover viewport with bold links and accent-colour hover states
- Ensure overlay links start hidden via script

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68a401d5ccf883229491b6e639472d76