### PR TITLE
Add service cards with pastel backgrounds

### DIFF
--- a/services.html
+++ b/services.html
@@ -24,32 +24,29 @@
 
   <main class="section glass fade-in">
     <h1>Services</h1>
-    <div class="service">
-      <h3>Professional Photography</h3>
-      <ul>
-        <li>Corporate and business photography</li>
-        <li>Event coverage (conferences, corporate events, private functions)</li>
-        <li>Product photography for e-commerce and marketing</li>
-        <li>Lifestyle and portrait photography</li>
-      </ul>
+    <div class="service-card service-blue">
+      <img src="https://img.icons8.com/color/96/camera--v1.png" alt="Camera icon">
+      <div>
+        <h3>Professional Photography</h3>
+        <p>Corporate events, product shoots, and lifestyle portraits delivered with a creative touch.</p>
+        <a href="#" class="btn btn-outline">Learn more →</a>
+      </div>
     </div>
-    <div class="service">
-      <h3>Videography Services</h3>
-      <ul>
-        <li>Commercial and promotional videos</li>
-        <li>Documentary-style storytelling</li>
-        <li>Wedding and event videography</li>
-        <li>Real estate and architectural videography</li>
-      </ul>
+    <div class="service-card service-pink">
+      <img src="https://img.icons8.com/color/96/video-camera--v1.png" alt="Video camera icon">
+      <div>
+        <h3>Videography Services</h3>
+        <p>Promotional films, documentary storytelling, and event coverage capturing every moment.</p>
+        <a href="#" class="btn btn-outline">Learn more →</a>
+      </div>
     </div>
-    <div class="service">
-      <h3>Media Production &amp; Editing</h3>
-      <ul>
-        <li>High-end video editing and post-production</li>
-        <li>Motion graphics and animation</li>
-        <li>Color grading and visual effects</li>
-        <li>Professional sound design and voiceovers</li>
-      </ul>
+    <div class="service-card service-violet">
+      <img src="https://img.icons8.com/color/96/clapperboard--v1.png" alt="Clapperboard icon">
+      <div>
+        <h3>Media Production &amp; Editing</h3>
+        <p>Polished editing, motion graphics, and sound design for high-impact media.</p>
+        <a href="#" class="btn btn-outline">Learn more →</a>
+      </div>
     </div>
 
     <h2>Gallery</h2>

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,12 @@
- :root {
+:root {
   --accent-color: #ef3c23; /* vibrant red */
   --text-color: #333333;
   --bg-color: rgba(246, 243, 232, 1);
   --panel-bg: rgba(255, 255, 255, 0.06);
   --panel-border: rgba(255, 255, 255, 0.18);
+  --accent-blue: 99, 102, 241;
+  --accent-pink: 236, 72, 153;
+  --accent-violet: 168, 85, 247;
 }
 
 * {
@@ -285,6 +288,42 @@ img {
 .service ul {
   list-style: disc;
   padding-left: 1.25rem;
+}
+
+.service-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-top: 2rem;
+}
+
+.service-card img {
+  width: 60px;
+  height: 60px;
+  flex-shrink: 0;
+}
+
+.service-card h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.service-card p {
+  margin-bottom: 1rem;
+}
+
+.service-blue {
+  background-color: rgba(var(--accent-blue), 0.15);
+}
+
+.service-pink {
+  background-color: rgba(var(--accent-pink), 0.15);
+}
+
+.service-violet {
+  background-color: rgba(var(--accent-violet), 0.15);
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- Replace service list with card layout featuring icons, descriptions, and call-to-action buttons
- Introduce pastel background utility classes leveraging new accent color variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a401d844ac8322a53e1868b7495e2c