### PR TITLE
Add responsive testimonials grid to numbers page

### DIFF
--- a/numbers.html
+++ b/numbers.html
@@ -28,6 +28,30 @@
       <div class="stat"><span class="stat-number" data-target="100">0</span>+ Moments Captured</div>
       <div class="stat"><span class="stat-number" data-target="98">0</span>% Client Satisfaction</div>
     </div>
+
+    <section class="testimonials">
+      <h2>What Clients Say</h2>
+      <div class="testimonials-grid">
+        <figure class="testimonial-card">
+          <blockquote>
+            “The Project Archive captured our wedding perfectly. Each photo is a treasure!”
+          </blockquote>
+          <figcaption>— Aishath & Ahmed</figcaption>
+        </figure>
+        <figure class="testimonial-card">
+          <blockquote>
+            “Their attention to detail is unmatched. We relive the day every time we look at our album.”
+          </blockquote>
+          <figcaption>— Leena</figcaption>
+        </figure>
+        <figure class="testimonial-card">
+          <blockquote>
+            “Professional, friendly, and incredibly talented. Highly recommend!”
+          </blockquote>
+          <figcaption>— Mariyam</figcaption>
+        </figure>
+      </div>
+    </section>
   </main>
 
   <footer class="footer"></footer>

--- a/styles.css
+++ b/styles.css
@@ -447,3 +447,40 @@ body.loaded .fade-in {
   opacity: 1;
   pointer-events: auto;
 }
+
+/* Testimonials */
+.testimonials-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 600px) {
+  .testimonials-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .testimonials-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.testimonial-card {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  color: var(--text-color);
+}
+
+.testimonial-card blockquote {
+  margin: 0 0 1rem 0;
+  font-style: italic;
+}
+
+.testimonial-card figcaption {
+  font-weight: 700;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- Add testimonials section to numbers page with three sample quotes.
- Style new testimonials grid with responsive columns, white cards, borders, and subtle shadows.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a401d9d3fc8322be59dff3367bc42c