### PR TITLE
Improve contact layout with highlight and icons

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
 </head>
 <body>
   <header class="site-header">
@@ -24,27 +25,36 @@
 
   <main class="section glass fade-in">
     <h1>Contact</h1>
-    <div class="contact-columns">
-      <div class="contact-info">
-        <p>Email: <a href="mailto:hello@theprojectarchive.mv">hello@theprojectarchive.mv</a></p>
-        <p>Phone: +960 7495687</p>
-        <p>Social: <a href="https://theprojectarchive.mv">theprojectarchive.mv</a></p>
+    <form class="contact-form" action="https://formspree.io/f/hello@theprojectarchive.mv" method="POST">
+      <label for="name">Name</label>
+      <input type="text" id="name" name="name" required>
+
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" required>
+
+      <label for="subject">Subject</label>
+      <input type="text" id="subject" name="subject" required>
+
+      <label for="message">Message</label>
+      <textarea id="message" name="message" rows="5" required></textarea>
+
+      <button type="submit">Send</button>
+    </form>
+
+    <div class="contact-bottom">
+      <div class="contact-row">
+        <div class="headline">Say hello.</div>
+        <div class="details">
+          <p class="email"><a href="mailto:hello@theprojectarchive.mv">hello@theprojectarchive.mv</a></p>
+          <p class="info phone">+960 7495687</p>
+          <p class="info location">Maldives</p>
+        </div>
       </div>
-      <form class="contact-form" action="https://formspree.io/f/hello@theprojectarchive.mv" method="POST">
-        <label for="name">Name</label>
-        <input type="text" id="name" name="name" required>
-
-        <label for="email">Email</label>
-        <input type="email" id="email" name="email" required>
-
-        <label for="subject">Subject</label>
-        <input type="text" id="subject" name="subject" required>
-
-        <label for="message">Message</label>
-        <textarea id="message" name="message" rows="5" required></textarea>
-
-        <button type="submit">Send</button>
-      </form>
+      <div class="social-icons">
+        <a href="mailto:hello@theprojectarchive.mv" aria-label="Email"><i class="fas fa-envelope"></i></a>
+        <a href="tel:+9607495687" aria-label="Phone"><i class="fas fa-phone"></i></a>
+        <a href="https://theprojectarchive.mv" aria-label="Website"><i class="fas fa-globe"></i></a>
+      </div>
     </div>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@
   --bg-color: rgba(246, 243, 232, 1);
   --panel-bg: rgba(255, 255, 255, 0.06);
   --panel-border: rgba(255, 255, 255, 0.18);
+  --bg-light: #ffffff;
 }
 
 * {
@@ -420,6 +421,61 @@ body.loaded .fade-in {
 
 .contact-form button:hover {
   background-color: #a0214d;
+}
+
+.contact-bottom {
+  margin-top: 2rem;
+  padding: 2rem;
+  background-color: var(--bg-light);
+  border-radius: 8px;
+}
+
+.contact-bottom .contact-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .contact-bottom .contact-row {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+.contact-bottom .headline {
+  font-weight: 700;
+  font-size: 1.5rem;
+}
+
+.contact-bottom .details {
+  text-align: right;
+}
+
+.contact-bottom .details .email {
+  color: var(--accent-color);
+  font-weight: 700;
+}
+
+.contact-bottom .details .info {
+  color: var(--text-color);
+  opacity: 0.7;
+}
+
+.social-icons {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 1rem;
+}
+
+.social-icons a {
+  color: var(--text-color);
+  font-size: 1.25rem;
+}
+
+.social-icons a:hover {
+  color: var(--accent-color);
 }
 
 .scroll-top {


### PR DESCRIPTION
## Summary
- Reworked contact section into a rounded panel with a "Say hello." headline and accent-coloured email.
- Introduced `--bg-light` theme variable and supporting styles for contact info and social icons.
- Added horizontal social icon links for email, phone, and website.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a401da3534832281d584fa882fc556