### PR TITLE
Add scroll-triggered section reveal and project strip snapping

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,8 +37,26 @@ function animateStats(root) {
   elements.forEach((el) => observer.observe(el));
 }
 
+function revealOnScroll(root) {
+  const elements = root.querySelectorAll('.fade-in');
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          obs.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.2 }
+  );
+
+  elements.forEach((el) => observer.observe(el));
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   document.body.classList.add('loaded');
+  revealOnScroll(document);
 
   const sections = {
     about: 'about.html',
@@ -61,6 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
           if (main) {
             container.innerHTML = main.innerHTML;
             animateStats(container);
+            revealOnScroll(container);
           }
         })
         .catch((err) => console.error(`Failed to load ${url}:`, err));

--- a/styles.css
+++ b/styles.css
@@ -313,7 +313,7 @@ body.loaded {
   transition: opacity 0.6s ease, transform 0.6s ease;
 }
 
-body.loaded .fade-in {
+.fade-in.visible {
   opacity: 1;
   transform: translateY(0);
 }
@@ -446,4 +446,18 @@ body.loaded .fade-in {
 .scroll-top.show {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* Horizontal project strip */
+.project-strip {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+.project-card {
+  flex: 0 0 auto;
+  scroll-snap-align: start;
 }


### PR DESCRIPTION
## Summary
- Add `revealOnScroll` IntersectionObserver to fade/slide sections into view
- Introduce scroll-snap styles for horizontal project strips

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a401db2504832286b3ebf4f598157c