### PR TITLE
Add descriptive alt text to hero and about images

### DIFF
--- a/about.html
+++ b/about.html
@@ -24,7 +24,7 @@
 
   <main class="section fade-in">
     <div class="info-card">
-      <img class="micro-illustration" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MCIgaGVpZ2h0PSI4MCIgdmlld0JveD0iMCAwIDgwIDgwIj4KICA8Y2lyY2xlIGN4PSI0MCIgY3k9IjQwIiByPSI0MCIgZmlsbD0iI2VmM2MyMyIvPgogIDxwYXRoIGQ9Ik00MCAxNUw0NyAzM0g2Nkw1MSA0NUw1OCA2M0w0MCA1MkwyMiA2M0wyOSA0NUwxNCAzM0gzM0w0MCAxNVoiIGZpbGw9IiNmZmZmZmYiLz4KPC9zdmc+Cg==" alt="" />
+      <img class="micro-illustration" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MCIgaGVpZ2h0PSI4MCIgdmlld0JveD0iMCAwIDgwIDgwIj4KICA8Y2lyY2xlIGN4PSI0MCIgY3k9IjQwIiByPSI0MCIgZmlsbD0iI2VmM2MyMyIvPgogIDxwYXRoIGQ9Ik00MCAxNUw0NyAzM0g2Nkw1MSA0NUw1OCA2M0w0MCA1MkwyMiA2M0wyOSA0NUwxNCAzM0gzM0w0MCAxNVoiIGZpbGw9IiNmZmZmZmYiLz4KPC9zdmc+Cg==" alt="White star on a red circle" />
       <h1><strong>About Us</strong><br><span class="secondary">Framing memories since 2024</span></h1>
       <p>The Project Archive is a <strong>creative studio</strong> based in the <strong>Maldives</strong>, dedicated to capturing life’s most meaningful moments. Founded in <strong>2024</strong> from a passion for storytelling, we’ve since grown into a <strong>full-service studio</strong> transforming weddings, events, and everyday stories into timeless keepsakes. We don’t just document scenes; we capture the laughter between the poses, the tears during vows, the energy on the dance floor, and the quiet moments in between—preserving memories that last a lifetime.</p>
     </div>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   </nav>
 
   <section id="home" class="hero fade-in">
-    <img class="hero-media" src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1920&q=80" alt="">
+    <img class="hero-media" src="https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1920&q=80" alt="A creative workspace with a camera and photo prints on a desk">
     <h1>The Project Archive</h1>
     <p class="tagline"></p>
     <div class="cta-group">


### PR DESCRIPTION
## Summary
- provide descriptive alt text for hero image on home page
- describe star illustration on about page

## Testing
- `npx pa11y file://$PWD/index.html` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npx html-validate index.html about.html`

------
https://chatgpt.com/codex/tasks/task_e_68a4075cd5a08322993848ab004160e7