### PR TITLE
Handle fetch failures gracefully

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,22 +63,32 @@ document.addEventListener('DOMContentLoaded', () => {
             animateStats(container);
           }
         })
-        .catch((err) => console.error(`Failed to load ${url}:`, err));
+        .catch((err) => {
+          console.error(`Failed to load ${url}:`, err);
+          container.innerHTML =
+            '<p class="fallback">Section unavailable. Please try again later.</p>';
+        });
     }
   });
 
+  const footerContainer = document.querySelector('footer.footer');
   fetch('footer.html')
     .then((r) => r.text())
     .then((html) => {
       const parser = new DOMParser();
       const doc = parser.parseFromString(html, 'text/html');
       const footer = doc.querySelector('footer');
-      const container = document.querySelector('footer.footer');
-      if (footer && container) {
-        container.innerHTML = footer.innerHTML;
+      if (footer && footerContainer) {
+        footerContainer.innerHTML = footer.innerHTML;
       }
     })
-    .catch((err) => console.error('Failed to load footer:', err));
+    .catch((err) => {
+      console.error('Failed to load footer:', err);
+      if (footerContainer) {
+        footerContainer.innerHTML =
+          '<p class="fallback">Section unavailable. Please try again later.</p>';
+      }
+    });
 
   animateStats(document);
 

--- a/styles.css
+++ b/styles.css
@@ -42,6 +42,14 @@ img {
   height: auto;
 }
 
+.fallback {
+  padding: 1rem;
+  text-align: center;
+  font-style: italic;
+  color: var(--text-color);
+  opacity: 0.7;
+}
+
 .site-header {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- Display fallback message when section or footer content fails to load.
- Add styling for fallback message to ensure visibility.

## Testing
- `node test_fetch.js` *(section renamed to simulate failure)*
- `node test_fetch.js` *(normal loading after restore)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4075f0de483228150d41daf3e98dd