### PR TITLE
Improve hero section contrast and CTA styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,12 @@
  :root {
   --accent-color: #ef3c23; /* vibrant red */
-  --text-color: #333333;
+  --color-dark-text: #333333;
+  --color-light-text: #ffffff;
   --bg-color: rgba(246, 243, 232, 1);
   --panel-bg: rgba(255, 255, 255, 0.06);
   --panel-border: rgba(255, 255, 255, 0.18);
   --bg-light: #ffffff;
-}
+ }
 
 * {
   box-sizing: border-box;
@@ -24,7 +25,7 @@ section {
 body {
   font-family: 'Montserrat', system-ui, sans-serif;
   line-height: 1.6;
-  color: var(--text-color);
+  color: var(--color-dark-text);
   background-color: var(--bg-color);
 }
 
@@ -46,7 +47,7 @@ img {
   padding: 1rem;
   text-align: center;
   font-style: italic;
-  color: var(--text-color);
+  color: var(--color-dark-text);
   opacity: 0.7;
 }
 
@@ -65,7 +66,7 @@ img {
 .logo {
   font-weight: 700;
   text-decoration: none;
-  color: var(--text-color);
+  color: var(--color-dark-text);
 }
 
 /* Overlay navigation */
@@ -95,7 +96,7 @@ img {
 }
 
 .overlay-nav a {
-  color: var(--text-color);
+  color: var(--color-dark-text);
   text-decoration: none;
   font-size: 2rem;
   line-height: 4rem;
@@ -123,7 +124,7 @@ img {
 .hamburger span {
   display: block;
   height: 2px;
-  background: var(--text-color);
+  background: var(--color-dark-text);
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
@@ -139,7 +140,7 @@ img {
   transform: translateY(-8px) rotate(-45deg);
 }
 
- .hero {
+.hero {
   position: relative;
   min-height: 100vh;
   display: flex;
@@ -150,16 +151,21 @@ img {
   overflow: hidden;
   padding: 2rem;
   margin-bottom: 2rem;
-  color: var(--bg-color);
- }
+  color: var(--color-light-text);
+}
 
- .hero::after {
+.hero::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.7) 0%,
+    rgba(0, 0, 0, 0.3) 50%,
+    rgba(0, 0, 0, 0.7) 100%
+  );
   z-index: 1;
- }
+}
 
  .hero-media {
   position: absolute;
@@ -178,18 +184,20 @@ img {
   z-index: 2;
  }
 
- .hero h1 {
-  font-size: clamp(3rem, 10vw, 6rem);
-  margin-bottom: 0.5rem;
+.hero h1 {
+  font-size: clamp(4rem, 12vw, 8rem);
+  margin-bottom: 1rem;
   color: var(--accent-color);
- }
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
 
 #typed-title {
   font: inherit;
 }
 
 .tagline {
-  font-size: 1.25rem;
+  font-size: 1.5rem;
   margin-bottom: 2rem;
 }
 
@@ -207,8 +215,9 @@ img {
   border-radius: 50px;
   text-decoration: none;
   background: var(--accent-color);
-  color: var(--bg-color);
-  transition: background 0.3s ease, color 0.3s ease;
+  color: var(--color-light-text);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  transition: background 0.3s ease, transform 0.3s ease, color 0.3s ease;
   cursor: pointer;
   font-weight: 700;
  }
@@ -216,7 +225,8 @@ img {
  .btn:hover,
  .btn:focus {
   background: #ff553f;
-  color: var(--bg-color);
+  color: var(--color-light-text);
+  transform: scale(1.05);
  }
 
 .section {
@@ -477,7 +487,7 @@ body.loaded .fade-in {
   right: 1rem;
   background: none;
   border: none;
-  color: var(--text-color);
+  color: var(--color-dark-text);
   font-size: 2rem;
   cursor: pointer;
 }
@@ -523,7 +533,7 @@ body.loaded .fade-in {
   border: none;
   border-radius: 4px;
   background-color: var(--accent-color);
-  color: var(--text-color);
+  color: var(--color-dark-text);
   font-weight: 700;
   cursor: pointer;
 }
@@ -568,7 +578,7 @@ body.loaded .fade-in {
 }
 
 .contact-bottom .details .info {
-  color: var(--text-color);
+  color: var(--color-dark-text);
   opacity: 0.7;
 }
 
@@ -579,7 +589,7 @@ body.loaded .fade-in {
 }
 
 .social-icons a {
-  color: var(--text-color);
+  color: var(--color-dark-text);
   font-size: 1.25rem;
 }
 
@@ -596,7 +606,7 @@ body.loaded .fade-in {
   border: none;
   border-radius: 50%;
   background-color: var(--accent-color);
-  color: var(--text-color);
+  color: var(--color-dark-text);
   font-size: 1.5rem;
   display: flex;
   align-items: center;
@@ -637,7 +647,7 @@ body.loaded .fade-in {
   border-radius: 8px;
   padding: 1.5rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  color: var(--text-color);
+  color: var(--color-dark-text);
 }
 
 .testimonial-card blockquote {


### PR DESCRIPTION
## Summary
- add dedicated dark/light text variables and remove hero text's reliance on background color
- replace hero overlay with a gradient, enlarge typography, and center headline/tagline
- enhance call-to-action buttons with accent colors, shadows, and hover scaling

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a40b66ba588322a268375a643d39e6