### PR TITLE
Refine overlay menu to match Loopcraft layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -112,26 +112,9 @@ document.addEventListener('DOMContentLoaded', () => {
     overlayNav.classList.remove('open');
     overlayNav.setAttribute('aria-hidden', 'true');
 
-    const mq = window.matchMedia('(min-width: 768px)');
-    const handleNavVisibility = (e) => {
-      if (e.matches) {
-        overlayNav.classList.remove('open');
-        body.classList.remove('open');
-        hamburger.classList.remove('open');
-        overlayNav.setAttribute('aria-hidden', 'false');
-        hamburger.style.display = 'none';
-      } else {
-        overlayNav.setAttribute('aria-hidden', 'true');
-        hamburger.style.display = '';
-      }
-    };
-    handleNavVisibility(mq);
-    mq.addEventListener('change', handleNavVisibility);
-
     let lastFocusedElement = null;
 
     const closeMenu = () => {
-      if (mq.matches) return;
       overlayNav.classList.remove('open');
       body.classList.remove('open');
       hamburger.classList.remove('open');
@@ -164,13 +147,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     overlayNav.addEventListener('click', (e) => {
-      if (e.target.matches('a') && !mq.matches) {
+      if (e.target.matches('a')) {
         closeMenu();
       }
     });
 
     overlayNav.addEventListener('keydown', (e) => {
-      if (mq.matches || !overlayNav.classList.contains('open') || e.key !== 'Tab') return;
+      if (!overlayNav.classList.contains('open') || e.key !== 'Tab') return;
       const focusable = overlayNav.querySelectorAll('a');
       if (!focusable.length) return;
       const first = focusable[0];

--- a/styles.css
+++ b/styles.css
@@ -54,6 +54,7 @@ img {
   position: fixed;
   top: 0;
   left: 0;
+  right: 0;
   width: 100%;
   display: flex;
   align-items: center;
@@ -73,7 +74,7 @@ img {
 .overlay-nav {
   position: fixed;
   inset: 0;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -85,7 +86,7 @@ img {
   visibility: hidden;
   pointer-events: none;
   transition: opacity 0.3s ease;
-  z-index: 1000;
+  z-index: 1200;
 }
 
 .overlay-nav.open {
@@ -117,7 +118,7 @@ img {
   background: none;
   border: none;
   cursor: pointer;
-  z-index: 1200;
+  z-index: 1300;
 }
 
 .hamburger span {
@@ -237,36 +238,6 @@ img {
   }
 }
 
-@media (min-width: 768px) {
-  .overlay-nav {
-    position: sticky;
-    top: 0;
-    bottom: auto;
-    left: 0;
-    right: 0;
-    flex-direction: row;
-    justify-content: flex-end;
-    background: rgba(246, 243, 232, 0.9);
-    backdrop-filter: blur(5px);
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-    gap: 2rem;
-    padding: 1rem 2rem;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  }
-
-  .overlay-nav a {
-    font-size: 1rem;
-    line-height: normal;
-    padding: 0.5rem;
-    font-weight: 700;
-  }
-
-  .hamburger {
-    display: none;
-  }
-}
 
 .section h2 {
   font-size: 2rem;


### PR DESCRIPTION
## Summary
- Update header and overlay navigation to resemble Loopcraft layout
- Remove desktop sticky nav behavior and show overlay only when hamburger toggled
- Ensure overlay menu covers viewport and toggle logic works across breakpoints

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a40b64bdac832283ab5989bf517eee