### PR TITLE
Position gallery scroll controls below cards

### DIFF
--- a/services.html
+++ b/services.html
@@ -56,8 +56,7 @@
     </div>
 
     <h2 class="text-2xl font-bold text-center">Gallery</h2>
-    <div class="gallery-wrapper relative">
-      <button class="gallery-scroll-btn gallery-scroll-left absolute left-0 top-1/2 -translate-y-1/2 z-10 bg-white text-gray-800 p-2 rounded-full shadow" aria-label="Scroll left">&#10094;</button>
+    <div class="gallery-wrapper">
       <div class="gallery flex overflow-x-auto gap-4 scroll-smooth">
         <div class="project-card bg-white rounded shadow overflow-hidden">
           <img src="https://source.unsplash.com/random/400x300?sig=1&photography" alt="Project 1" class="w-full h-48 object-cover">
@@ -84,7 +83,10 @@
           <span class="project-title block p-2 font-semibold">Project 6</span>
         </div>
       </div>
-      <button class="gallery-scroll-btn gallery-scroll-right absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-white text-gray-800 p-2 rounded-full shadow" aria-label="Scroll right">&#10095;</button>
+      <div class="flex justify-center gap-4 mt-4">
+        <button class="gallery-scroll-btn gallery-scroll-left bg-white text-gray-800 p-2 rounded-full shadow" aria-label="Scroll left">&#10094;</button>
+        <button class="gallery-scroll-btn gallery-scroll-right bg-white text-gray-800 p-2 rounded-full shadow" aria-label="Scroll right">&#10095;</button>
+      </div>
     </div>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -418,13 +418,6 @@ body.loaded .fade-in {
   cursor: pointer;
 }
 
-.gallery-scroll-left {
-  left: 0.5rem;
-}
-
-.gallery-scroll-right {
-  right: 0.5rem;
-}
 
 .project-card {
   position: relative;


### PR DESCRIPTION
## Summary
- Move gallery scroll buttons below the project cards and center them
- Remove unused side offset CSS for gallery scroll buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a417ad31888322a0d1c62de84d1e84