### PR TITLE
feat(services): add Loopcraft-style horizontal card rail with snap, arrows & drag

### DIFF
--- a/script.js
+++ b/script.js
@@ -289,3 +289,49 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+
+(function () {
+  const rail = document.querySelector('.srv-track');
+  if (!rail) return;
+
+  const left = document.querySelector('.srv-arrow.left');
+  const right = document.querySelector('.srv-arrow.right');
+
+  function updateArrows() {
+    const max = rail.scrollWidth - rail.clientWidth - 1;
+    left.disabled = rail.scrollLeft <= 0;
+    right.disabled = rail.scrollLeft >= max;
+  }
+  function scrollByCard(dir = 1) {
+    const amount = Math.min(rail.clientWidth * 0.9, 700);
+    rail.scrollBy({ left: dir * amount, behavior: 'smooth' });
+    setTimeout(updateArrows, 400);
+  }
+
+  left?.addEventListener('click', () => scrollByCard(-1));
+  right?.addEventListener('click', () => scrollByCard(1));
+  rail.addEventListener('scroll', updateArrows);
+  window.addEventListener('resize', updateArrows);
+  updateArrows();
+
+  // drag-to-scroll
+  let isDown = false, startX = 0, startLeft = 0;
+  rail.addEventListener('pointerdown', (e) => {
+    isDown = true; rail.setPointerCapture(e.pointerId);
+    startX = e.clientX; startLeft = rail.scrollLeft;
+  });
+  rail.addEventListener('pointermove', (e) => {
+    if (!isDown) return;
+    const dx = e.clientX - startX;
+    rail.scrollLeft = startLeft - dx;
+  });
+  rail.addEventListener('pointerup', () => (isDown = false));
+  rail.addEventListener('pointercancel', () => (isDown = false));
+
+  // keyboard support (when rail is focused)
+  rail.tabIndex = 0;
+  rail.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowRight') { e.preventDefault(); scrollByCard(1); }
+    if (e.key === 'ArrowLeft')  { e.preventDefault(); scrollByCard(-1); }
+  });
+})();

--- a/services.html
+++ b/services.html
@@ -24,36 +24,68 @@
   </header>
 
   <main class="section fade-in py-16 px-4 space-y-8">
-    <h1 class="text-3xl font-bold text-center">Services</h1>
-    <div class="services flex flex-col gap-8">
-      <div class="service-card bg-white rounded shadow p-6 space-y-4">
-        <h3 class="text-xl font-semibold">Professional Photography</h3>
-        <ul class="list-disc pl-5 space-y-1">
-          <li>Corporate and business photography</li>
-          <li>Event coverage (conferences, corporate events, private functions)</li>
-          <li>Product photography for e-commerce and marketing</li>
-          <li>Lifestyle and portrait photography</li>
-        </ul>
+    <section id="services" class="services">
+      <div class="container">
+        <h2 class="section-title">Services</h2>
+
+        <div class="srv-rail">
+          <button class="srv-arrow left" aria-label="Scroll left" tabindex="0">‹</button>
+
+          <div class="srv-track" role="list" aria-label="Our services">
+            <!-- Card 1 -->
+            <article class="srv-card" role="listitem">
+              <div class="srv-card__copy">
+                <span class="srv-eyebrow">E-COMMERCE</span>
+                <h3 class="srv-title">Build your online store,<br>make selling easy.</h3>
+                <p class="srv-desc">
+                  Store setup, payments, product pages, and analytics configured for growth.
+                </p>
+                <a class="srv-cta" href="#contact">Learn more →</a>
+              </div>
+              <div class="srv-card__media">
+                <img src="images/ecommerce.jpg" alt="E-commerce storefront preview" loading="lazy">
+              </div>
+            </article>
+
+            <!-- Card 2 -->
+            <article class="srv-card" role="listitem">
+              <div class="srv-card__copy">
+                <span class="srv-eyebrow">HUMANLOT</span>
+                <h3 class="srv-title">For productive teams &amp;<br>happier employees</h3>
+                <p class="srv-desc">
+                  HR tools that streamline attendance, leave, and performance in one place.
+                </p>
+                <a class="srv-cta" href="#contact">Learn more →</a>
+              </div>
+              <div class="srv-card__media">
+                <img src="images/hr-app.jpg" alt="HR mobile app preview" loading="lazy">
+              </div>
+            </article>
+
+            <!-- Card 3 (example) -->
+            <article class="srv-card" role="listitem">
+              <div class="srv-card__copy">
+                <span class="srv-eyebrow">CONTENT</span>
+                <h3 class="srv-title">Brand content that feels<br>alive &amp; consistent</h3>
+                <p class="srv-desc">
+                  Campaign strategy, photo/video production, and social systems that scale.
+                </p>
+                <a class="srv-cta" href="#contact">Learn more →</a>
+              </div>
+              <div class="srv-card__media">
+                <img src="images/content.jpg" alt="Content production preview" loading="lazy">
+              </div>
+            </article>
+          </div>
+
+          <button class="srv-arrow right" aria-label="Scroll right" tabindex="0">›</button>
+
+          <!-- fade edges -->
+          <div class="srv-fade left"></div>
+          <div class="srv-fade right"></div>
+        </div>
       </div>
-      <div class="service-card bg-white rounded shadow p-6 space-y-4">
-        <h3 class="text-xl font-semibold">Videography Services</h3>
-        <ul class="list-disc pl-5 space-y-1">
-          <li>Commercial and promotional videos</li>
-          <li>Documentary-style storytelling</li>
-          <li>Wedding and event videography</li>
-          <li>Real estate and architectural videography</li>
-        </ul>
-      </div>
-      <div class="service-card bg-white rounded shadow p-6 space-y-4">
-        <h3 class="text-xl font-semibold">Media Production &amp; Editing</h3>
-        <ul class="list-disc pl-5 space-y-1">
-          <li>High-end video editing and post-production</li>
-          <li>Motion graphics and animation</li>
-          <li>Color grading and visual effects</li>
-          <li>Professional sound design and voiceovers</li>
-        </ul>
-      </div>
-    </div>
+    </section>
 
     <h2 class="text-2xl font-bold text-center">Gallery</h2>
     <div class="gallery-wrapper">

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,18 @@
- :root {
+:root {
   --accent-color: #ef3c23; /* vibrant red */
   --text-color: #333333;
   --bg-color: rgba(246, 243, 232, 1);
   --panel-bg: rgba(255, 255, 255, 0.06);
   --panel-border: rgba(255, 255, 255, 0.18);
-  --bg-light: #ffffff;
+  --bg-light: #F8F9FB;
   --color-dark-text: #333333;
+  --text-dark: #05192D;
+  --muted: #6B7280;
+  --card-bg: #FFFFFF;
+  --accent-blue: #2B60FF;
+  --accent-pink: #FF4175;
+  --accent-violet: #7928CA;
+  --radius-xl: 24px;
 }
 
 * {
@@ -657,4 +664,76 @@ body.loaded .fade-in {
 .testimonial-card figcaption {
   font-weight: 700;
   text-align: right;
+}
+
+/* Services rail */
+.services { padding: 80px 0; background: var(--bg-light); }
+.section-title { color: var(--text-dark); font-size: clamp(28px, 4vw, 44px); margin: 0 0 28px; }
+
+.srv-rail { position: relative; }
+.srv-track {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: min(88vw, 760px);
+  gap: 28px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  padding: 8px 16px 16px;
+}
+.srv-track::-webkit-scrollbar { height: 0; }
+
+.srv-card {
+  background: var(--card-bg);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 10px 30px rgba(5, 25, 45, 0.08);
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  align-items: center;
+  padding: 28px;
+  scroll-snap-align: start;
+  min-height: 360px;
+}
+.srv-card__copy { padding-right: 20px; }
+.srv-card__media img {
+  width: 100%; height: 100%; object-fit: cover;
+  border-radius: calc(var(--radius-xl) - 6px);
+}
+
+.srv-eyebrow {
+  display: inline-block;
+  font-size: 12px; letter-spacing: .12em;
+  color: var(--accent-violet);
+  text-transform: uppercase; margin-bottom: 10px;
+}
+.srv-title { font-size: clamp(22px, 3.2vw, 38px); line-height: 1.1; color: var(--text-dark); margin: 0 0 12px; }
+.srv-desc { color: var(--muted); margin: 0 0 16px; }
+.srv-cta {
+  display: inline-block; padding: 10px 14px; border-radius: 999px;
+  border: 1px solid currentColor; color: var(--accent-blue); text-decoration: none;
+}
+.srv-cta:hover { background: var(--accent-blue); color: #fff; }
+
+.srv-arrow {
+  position: absolute; top: 50%; transform: translateY(-50%);
+  z-index: 3;
+  width: 40px; height: 40px; border-radius: 999px;
+  border: none; background: #fff; color: var(--text-dark);
+  box-shadow: 0 6px 18px rgba(5,25,45,.12); cursor: pointer;
+}
+.srv-arrow.left { left: 8px; }
+.srv-arrow.right { right: 8px; }
+.srv-arrow:disabled { opacity: .4; cursor: default; }
+
+.srv-fade {
+  pointer-events: none; position: absolute; top: 0; bottom: 0; width: 56px; z-index: 2;
+  background: linear-gradient(to right, var(--bg-light), rgba(248,249,251,0));
+}
+.srv-fade.left { left: 0; }
+.srv-fade.right { right: 0; transform: scaleX(-1); }
+
+@media (max-width: 900px) {
+  .srv-card { grid-template-columns: 1fr; gap: 14px; min-height: 0; }
+  .srv-card__copy { padding-right: 0; }
+  .srv-track { grid-auto-columns: 88vw; }
 }


### PR DESCRIPTION
## Summary
- redesign Services section with horizontal snap-scrolling cards and fade edges
- style rail, cards and controls with new theme variables
- add JS helpers for arrow, drag and keyboard scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a41a6699248322a63c912523f87cb0