### PR TITLE
fix: initialize service rail and card animations

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -693,11 +693,19 @@ body.loaded .fade-in {
   padding: 28px;
   scroll-snap-align: start;
   min-height: 360px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
 }
 .srv-card__copy { padding-right: 20px; }
 .srv-card__media img {
   width: 100%; height: 100%; object-fit: cover;
   border-radius: calc(var(--radius-xl) - 6px);
+}
+
+.srv-card.show {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .srv-eyebrow {


### PR DESCRIPTION
## Summary
- animate service cards by targeting both legacy and new classes
- initialize service rail on dynamically loaded content
- add opacity/transition styles for service cards

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a41f38182c83228b41839b423c0445