### PR TITLE
feat: make service cards scroll vertically

### DIFF
--- a/script.js
+++ b/script.js
@@ -88,36 +88,36 @@ function initServiceRail(root) {
   const rail = root.querySelector('.srv-track');
   if (!rail) return;
 
-  const left = root.querySelector('.srv-arrow.left');
-  const right = root.querySelector('.srv-arrow.right');
+  const up = root.querySelector('.srv-arrow.up');
+  const down = root.querySelector('.srv-arrow.down');
 
   function updateArrows() {
-    const max = rail.scrollWidth - rail.clientWidth - 1;
-    if (left) left.disabled = rail.scrollLeft <= 0;
-    if (right) right.disabled = rail.scrollLeft >= max;
+    const max = rail.scrollHeight - rail.clientHeight - 1;
+    if (up) up.disabled = rail.scrollTop <= 0;
+    if (down) down.disabled = rail.scrollTop >= max;
   }
   function scrollByCard(dir = 1) {
-    const amount = Math.min(rail.clientWidth * 0.9, 700);
-    rail.scrollBy({ left: dir * amount, behavior: 'smooth' });
+    const amount = Math.min(rail.clientHeight * 0.9, 700);
+    rail.scrollBy({ top: dir * amount, behavior: 'smooth' });
     setTimeout(updateArrows, 400);
   }
 
-  left?.addEventListener('click', () => scrollByCard(-1));
-  right?.addEventListener('click', () => scrollByCard(1));
+  up?.addEventListener('click', () => scrollByCard(-1));
+  down?.addEventListener('click', () => scrollByCard(1));
   rail.addEventListener('scroll', updateArrows);
   window.addEventListener('resize', updateArrows);
   updateArrows();
 
   // drag-to-scroll
-  let isDown = false, startX = 0, startLeft = 0;
+  let isDown = false, startY = 0, startTop = 0;
   rail.addEventListener('pointerdown', (e) => {
     isDown = true; rail.setPointerCapture(e.pointerId);
-    startX = e.clientX; startLeft = rail.scrollLeft;
+    startY = e.clientY; startTop = rail.scrollTop;
   });
   rail.addEventListener('pointermove', (e) => {
     if (!isDown) return;
-    const dx = e.clientX - startX;
-    rail.scrollLeft = startLeft - dx;
+    const dy = e.clientY - startY;
+    rail.scrollTop = startTop - dy;
   });
   rail.addEventListener('pointerup', () => (isDown = false));
   rail.addEventListener('pointercancel', () => (isDown = false));
@@ -125,8 +125,8 @@ function initServiceRail(root) {
   // keyboard support (when rail is focused)
   rail.tabIndex = 0;
   rail.addEventListener('keydown', (e) => {
-    if (e.key === 'ArrowRight') { e.preventDefault(); scrollByCard(1); }
-    if (e.key === 'ArrowLeft')  { e.preventDefault(); scrollByCard(-1); }
+    if (e.key === 'ArrowDown') { e.preventDefault(); scrollByCard(1); }
+    if (e.key === 'ArrowUp')  { e.preventDefault(); scrollByCard(-1); }
   });
 }
 

--- a/services.html
+++ b/services.html
@@ -29,7 +29,7 @@
         <h2 class="section-title">Services</h2>
 
         <div class="srv-rail">
-          <button class="srv-arrow left" aria-label="Scroll left" tabindex="0">‹</button>
+          <button class="srv-arrow up" aria-label="Scroll up" tabindex="0">▲</button>
 
           <div class="srv-track" role="list" aria-label="Our services">
             <!-- Card 1 -->
@@ -78,11 +78,11 @@
             </article>
           </div>
 
-          <button class="srv-arrow right" aria-label="Scroll right" tabindex="0">›</button>
+          <button class="srv-arrow down" aria-label="Scroll down" tabindex="0">▼</button>
 
           <!-- fade edges -->
-          <div class="srv-fade left"></div>
-          <div class="srv-fade right"></div>
+          <div class="srv-fade top"></div>
+          <div class="srv-fade bottom"></div>
         </div>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -673,15 +673,15 @@ body.loaded .fade-in {
 .srv-rail { position: relative; }
 .srv-track {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: min(88vw, 760px);
+  grid-auto-flow: row;
   gap: 28px;
-  overflow-x: auto;
-  scroll-snap-type: x mandatory;
+  max-height: 80vh;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
   scroll-behavior: smooth;
-  padding: 8px 16px 16px;
+  padding: 16px 8px;
 }
-.srv-track::-webkit-scrollbar { height: 0; }
+.srv-track::-webkit-scrollbar { width: 0; }
 
 .srv-card {
   background: var(--card-bg);
@@ -723,25 +723,24 @@ body.loaded .fade-in {
 .srv-cta:hover { background: var(--accent-blue); color: #fff; }
 
 .srv-arrow {
-  position: absolute; top: 50%; transform: translateY(-50%);
+  position: absolute; left: 50%; transform: translateX(-50%);
   z-index: 3;
   width: 40px; height: 40px; border-radius: 999px;
   border: none; background: #fff; color: var(--text-dark);
   box-shadow: 0 6px 18px rgba(5,25,45,.12); cursor: pointer;
 }
-.srv-arrow.left { left: 8px; }
-.srv-arrow.right { right: 8px; }
+.srv-arrow.up { top: 8px; }
+.srv-arrow.down { bottom: 8px; }
 .srv-arrow:disabled { opacity: .4; cursor: default; }
 
 .srv-fade {
-  pointer-events: none; position: absolute; top: 0; bottom: 0; width: 56px; z-index: 2;
-  background: linear-gradient(to right, var(--bg-light), rgba(248,249,251,0));
+  pointer-events: none; position: absolute; left: 0; right: 0; height: 56px; z-index: 2;
+  background: linear-gradient(to bottom, var(--bg-light), rgba(248,249,251,0));
 }
-.srv-fade.left { left: 0; }
-.srv-fade.right { right: 0; transform: scaleX(-1); }
+.srv-fade.top { top: 0; }
+.srv-fade.bottom { bottom: 0; transform: scaleY(-1); }
 
 @media (max-width: 900px) {
   .srv-card { grid-template-columns: 1fr; gap: 14px; min-height: 0; }
   .srv-card__copy { padding-right: 0; }
-  .srv-track { grid-auto-columns: 88vw; }
 }


### PR DESCRIPTION
## Summary
- switch service cards to vertical scrolling with up/down controls
- update styles and script for vertical rail and fade effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a420c4fe0c8322a8e5c2d903e02e6e