### PR TITLE
refactor: adopt canonical design tokens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,61 @@
 :root {
-  --accent-color: #ef3c23; /* vibrant red */
-  --text-color: #333333;
-  --bg-color: rgba(246, 243, 232, 1);
-  --panel-bg: rgba(255, 255, 255, 0.06);
-  --panel-border: rgba(255, 255, 255, 0.18);
-  --bg-light: #F8F9FB;
-  --color-dark-text: #333333;
-  --text-dark: #05192D;
-  --muted: #6B7280;
-  --card-bg: #FFFFFF;
-  --accent-blue: #2B60FF;
-  --accent-pink: #FF4175;
-  --accent-violet: #7928CA;
-  --radius-xl: 24px;
+  /* Colors */
+  --color-accent: #ef3c23;
+  --color-text: #333333;
+  --color-background: #f6f3e8;
+  --color-surface: rgba(255, 255, 255, 0.06);
+  --color-surface-border: rgba(255, 255, 255, 0.18);
+  --color-background-light: #f8f9fb;
+  --color-text-dark: #05192d;
+  --color-muted: #6b7280;
+  --color-card: #ffffff;
+  --color-blue: #2b60ff;
+  --color-pink: #ff4175;
+  --color-violet: #7928ca;
+
+  /* Spacing */
+  --space-2xs: 0.25rem;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+
+  /* Radius */
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-2xl: 24px;
+  --radius-full: 9999px;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.15);
+
+  /* Typography */
+  --font-sans: 'Montserrat', system-ui, sans-serif;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.875rem;
+  --text-4xl: 2.25rem;
+  --font-normal: 400;
+  --font-bold: 700;
+
+  /* Layout */
+  --content-max: 1200px;
+  --nav-height: 80px;
+  --z-nav: 1100;
+  --z-overlay: 1200;
+  --z-menu: 1300;
+  --z-modal: 1500;
 }
 
 * {
@@ -26,23 +69,23 @@ html {
 }
 
 section {
-  scroll-margin-top: 80px;
+  scroll-margin-top: var(--nav-height);
 }
 
 body {
-  font-family: 'Montserrat', system-ui, sans-serif;
+  font-family: var(--font-sans);
   line-height: 1.6;
-  color: var(--text-color);
-  background-color: var(--bg-color);
+  color: var(--color-text);
+  background-color: var(--color-background);
 }
 
 a {
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 a:hover {
   text-decoration: underline;
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 img {
@@ -54,7 +97,7 @@ img {
   padding: 1rem;
   text-align: center;
   font-style: italic;
-  color: var(--text-color);
+  color: var(--color-text);
   opacity: 0.7;
 }
 
@@ -68,13 +111,13 @@ img {
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.5rem;
-  z-index: 1100;
+  z-index: var(--z-nav);
 }
 
 .logo {
   font-weight: 700;
   text-decoration: none;
-  color: var(--text-color);
+  color: var(--color-text);
 }
 
 /* Overlay navigation */
@@ -94,7 +137,7 @@ img {
   visibility: hidden;
   pointer-events: none;
   transition: opacity 0.3s ease;
-  z-index: 1200;
+  z-index: var(--z-overlay);
 }
 
 .overlay-nav.open {
@@ -104,7 +147,7 @@ img {
 }
 
 .overlay-nav a {
-  color: var(--text-color);
+  color: var(--color-text);
   text-decoration: none;
   font-size: 2rem;
   line-height: 4rem;
@@ -114,7 +157,7 @@ img {
 
 .overlay-nav a:hover,
 .overlay-nav a:focus {
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 .hamburger {
@@ -126,13 +169,13 @@ img {
   background: none;
   border: none;
   cursor: pointer;
-  z-index: 1300;
+  z-index: var(--z-menu);
 }
 
 .hamburger span {
   display: block;
   height: 2px;
-  background: var(--text-color);
+  background: var(--color-text);
   transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
@@ -159,7 +202,7 @@ img {
   overflow: hidden;
   padding: 2rem;
   margin-bottom: 2rem;
-  color: var(--bg-color);
+  color: var(--color-background);
  }
 
  .hero::after {
@@ -190,7 +233,7 @@ img {
  .hero h1 {
   font-size: clamp(3rem, 10vw, 6rem);
   margin-bottom: 0.5rem;
-  color: var(--accent-color);
+  color: var(--color-accent);
  }
 
 #typed-title {
@@ -201,11 +244,11 @@ img {
   font-size: 1.25rem;
   margin-bottom: 2rem;
   font-weight: 700;
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 .typed-cursor {
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 .cta-group {
@@ -221,8 +264,8 @@ img {
   border: none;
   border-radius: 50px;
   text-decoration: none;
-  background: var(--accent-color);
-  color: var(--bg-color);
+  background: var(--color-accent);
+  color: var(--color-background);
   transition: background 0.3s ease, color 0.3s ease;
   cursor: pointer;
   font-weight: 700;
@@ -231,7 +274,7 @@ img {
  .btn:hover,
  .btn:focus {
   background: #ff553f;
-  color: var(--bg-color);
+  color: var(--color-background);
  }
 
 .section {
@@ -263,7 +306,7 @@ img {
   font-size: 2rem;
   margin: 0 auto 1rem;
   text-align: center;
-  border-bottom: 2px solid var(--accent-color);
+  border-bottom: 2px solid var(--color-accent);
   display: inline-block;
   padding-bottom: 0.25rem;
 }
@@ -279,7 +322,7 @@ img {
 }
 
 .info-card {
-  background: var(--bg-light);
+  background: var(--color-background-light);
   border-radius: 24px;
   padding: 2rem;
   margin: 2rem auto;
@@ -320,8 +363,8 @@ img {
 }
 
 .glass {
-  background: var(--panel-bg);
-  border: 1px solid var(--panel-border);
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-border);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-radius: 10px;
@@ -345,7 +388,7 @@ img {
   display: block;
   font-size: 3rem;
   font-weight: 800;
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 .service {
@@ -355,7 +398,7 @@ img {
 .service h3 {
   font-size: 1.25rem;
   margin-bottom: 0.5rem;
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 .service ul {
@@ -371,7 +414,7 @@ img {
 }
 
 .footer a {
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 body {
@@ -436,7 +479,7 @@ body.loaded {
   position: relative;
   border-radius: 8px;
   overflow: hidden;
-  background: linear-gradient(135deg, var(--accent-color), #ff7a5c);
+  background: linear-gradient(135deg, var(--color-accent), #ff7a5c);
   transition: transform 0.3s ease;
   width: 322px;
   height: 480px;
@@ -477,7 +520,7 @@ body.loaded {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;
-  z-index: 1200;
+  z-index: var(--z-overlay);
 }
 
 .lightbox.open {
@@ -497,7 +540,7 @@ body.loaded {
   right: 1rem;
   background: none;
   border: none;
-  color: var(--text-color);
+  color: var(--color-text);
   font-size: 2rem;
   cursor: pointer;
 }
@@ -527,7 +570,7 @@ body.loaded {
 
 .contact-form label {
   font-weight: 700;
-  color: var(--accent-color);
+  color: var(--color-accent);
   opacity: 1;
 }
 
@@ -536,16 +579,16 @@ body.loaded {
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
-  background: var(--bg-light);
-  color: var(--color-dark-text);
+  background: var(--color-background-light);
+  color: var(--color-text-dark);
 }
 
 .contact-form button {
   padding: 0.75rem;
   border: none;
   border-radius: 4px;
-  background-color: var(--accent-color);
-  color: var(--text-color);
+  background-color: var(--color-accent);
+  color: var(--color-text);
   font-weight: 700;
   cursor: pointer;
 }
@@ -557,7 +600,7 @@ body.loaded {
 .contact-bottom {
   margin-top: 2rem;
   padding: 2rem;
-  background-color: var(--bg-light);
+  background-color: var(--color-background-light);
   border-radius: 8px;
 }
 
@@ -578,7 +621,7 @@ body.loaded {
 .contact-bottom .headline {
   font-weight: 700;
   font-size: 1.5rem;
-  color: var(--accent-color);
+  color: var(--color-accent);
   opacity: 1;
 }
 
@@ -587,12 +630,12 @@ body.loaded {
 }
 
 .contact-bottom .details .email {
-  color: var(--accent-color);
+  color: var(--color-accent);
   font-weight: 700;
 }
 
 .contact-bottom .details .info {
-  color: var(--text-color);
+  color: var(--color-text);
   opacity: 1;
 }
 
@@ -603,12 +646,12 @@ body.loaded {
 }
 
 .social-icons a {
-  color: var(--text-color);
+  color: var(--color-text);
   font-size: 1.25rem;
 }
 
 .social-icons a:hover {
-  color: var(--accent-color);
+  color: var(--color-accent);
 }
 
 .scroll-top {
@@ -619,8 +662,8 @@ body.loaded {
   height: 3rem;
   border: none;
   border-radius: 50%;
-  background-color: var(--accent-color);
-  color: var(--text-color);
+  background-color: var(--color-accent);
+  color: var(--color-text);
   font-size: 1.5rem;
   display: flex;
   align-items: center;
@@ -629,7 +672,7 @@ body.loaded {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;
-  z-index: 1500;
+  z-index: var(--z-modal);
 }
 
 .scroll-top.show {
@@ -660,7 +703,7 @@ body.loaded {
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   padding: 1.5rem;
-  color: var(--text-color);
+  color: var(--color-text);
 }
 
 .testimonial-card blockquote {
@@ -674,8 +717,8 @@ body.loaded {
 }
 
 /* Services rail */
-.services { padding: 80px 0; background: var(--bg-light); }
-.section-title { color: var(--text-dark); font-size: clamp(28px, 4vw, 44px); margin: 0 0 28px; }
+.services { padding: 80px 0; background: var(--color-background-light); }
+.section-title { color: var(--color-text-dark); font-size: clamp(28px, 4vw, 44px); margin: 0 0 28px; }
 
 
 /* Layout for stacked service cards */
@@ -686,8 +729,8 @@ body.loaded {
 }
 
 .srv-card {
-  background: var(--card-bg);
-  border-radius: var(--radius-xl);
+  background: var(--color-card);
+  border-radius: var(--radius-2xl);
   box-shadow: 0 10px 30px rgba(5, 25, 45, 0.08);
   display: grid;
   grid-template-columns: 1fr;
@@ -700,7 +743,7 @@ body.loaded {
 .srv-card__copy { padding-right: 0; }
 .srv-card__media img {
   width: 100%; height: 100%; object-fit: cover;
-  border-radius: calc(var(--radius-xl) - 6px);
+  border-radius: calc(var(--radius-2xl) - 6px);
 }
 
 .srv-card.show {
@@ -711,14 +754,14 @@ body.loaded {
 .srv-eyebrow {
   display: inline-block;
   font-size: 12px; letter-spacing: .12em;
-  color: var(--accent-violet);
+  color: var(--color-violet);
   text-transform: uppercase; margin-bottom: 10px;
 }
-.srv-title { font-size: clamp(22px, 3.2vw, 38px); line-height: 1.1; color: var(--text-dark); margin: 0 0 12px; }
-.srv-desc { color: var(--muted); margin: 0 0 16px; }
+.srv-title { font-size: clamp(22px, 3.2vw, 38px); line-height: 1.1; color: var(--color-text-dark); margin: 0 0 12px; }
+.srv-desc { color: var(--color-muted); margin: 0 0 16px; }
 .srv-cta {
   display: inline-block; padding: 10px 14px; border-radius: 999px;
-  border: 1px solid currentColor; color: var(--accent-blue); text-decoration: none;
+  border: 1px solid currentColor; color: var(--color-blue); text-decoration: none;
 }
-.srv-cta:hover { background: var(--accent-blue); color: #fff; }
+.srv-cta:hover { background: var(--color-blue); color: #fff; }
 


### PR DESCRIPTION
## Summary
- replace `:root` variables with canonical color, spacing, radius, elevation, typography and layout tokens
- update stylesheet to use new token names for colors, radii and z-index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a47a25a9d883229bd2e7ed2f54077f