### PR TITLE
Add coming soon page with global redirect

### DIFF
--- a/comingsoon.html
+++ b/comingsoon.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Coming Soon - The Project Archive</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="font-sans bg-gray-50 flex items-center justify-center min-h-screen text-center p-4">
+  <div>
+    <h1 class="text-4xl font-bold mb-4">We're Coming Soon</h1>
+    <p class="text-gray-600">Our website is under construction. Please check back soon.</p>
+  </div>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,8 @@
+// Temporary redirect to coming soon page
+if (!window.location.pathname.endsWith("comingsoon.html")) {
+  window.location.replace("comingsoon.html");
+}
+
 function animateStats(root) {
   const elements = root.querySelectorAll('.stat-number');
   const animateElement = (el) => {


### PR DESCRIPTION
## Summary
- add simple `comingsoon.html` landing page for development stage
- redirect all pages to the coming soon page via `script.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b232c6e8832280b675e32c541aa1