### PR TITLE
chore: configure static output directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  BUILD_DIR: dist
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: dist
+          path: ${{ env.BUILD_DIR }}
 
   deploy:
     needs: build
@@ -27,12 +30,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: dist
-          path: dist
+          path: ${{ env.BUILD_DIR }}
       - name: Deploy to DigitalOcean
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.DO_SSH_HOST }}
           username: ${{ secrets.DO_SSH_USER }}
           key: ${{ secrets.DO_SSH_KEY }}
-          source: "dist/*"
+          source: "${{ env.BUILD_DIR }}/*"
           target: ${{ secrets.DO_DEPLOY_PATH }}

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: 'dist',
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vite to output production build to `dist`
- reference build directory in deploy workflow through a `BUILD_DIR` variable

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0088b141883229a4bf980e9f1119e