### PR TITLE
Configure legacy Node.js buildpack

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,7 +1,8 @@
 static_sites:
   - name: theprojectarchive
     source_dir: /
-    build_command: ""
-    output_dir: /
+    build_command: "npm install && npm run build"
+    output_dir: dist
+    buildpack: paketo-buildpacks/nodejs-legacy
     routes:
       - path: /

--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ GitHub Actions in `.github/workflows/deploy.yml` builds the site and deploys the
 - `DO_DEPLOY_PATH` – Target path on the Droplet
 
 Optional assets can be served from a DigitalOcean Space; see `.env.example` for configuration.
+
+## Buildpack Deployment
+
+The site can be built and deployed using [Paketo Buildpacks](https://paketo.io/). The included `project.toml` configures the `paketo-buildpacks/nodejs-legacy` buildpack and pins Node.js to version `18.x`.
+
+When deploying to platforms like DigitalOcean App Platform, the `.do/app.yaml` file specifies the build command and output directory so the built assets in `dist/` are served.
+
+### Environment variables
+
+- `BP_NODE_VERSION` – Node runtime used during build (e.g., `18.x`).
+- `NODE_ENV` – set to `production` for optimized runtime behavior.
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "framer-motion": "^12.23.12",
     "react": "^19.1.1",

--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,5 @@
+[[build.buildpacks]]
+id = "paketo-buildpacks/nodejs-legacy"
+
+[[build.env]]
+BP_NODE_VERSION = "18.x"


### PR DESCRIPTION
## Summary
- add Paketo legacy Node.js buildpack with pinned Node 18 runtime
- configure DigitalOcean App Platform to build into `dist` with Node buildpack
- document buildpack deployment and expected Node version

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c00af428dc8322968b4225b2e16190