### PR TITLE
chore: clarify static site output directory

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -2,7 +2,9 @@ static_sites:
   - name: theprojectarchive
     source_dir: /
     build_command: "npm install && npm run build"
-    output_dir: dist
+    # Generated assets are written to the "dist" directory by Vite.
+    # Make the path explicit so the App Platform knows where to find them.
+    output_dir: ./dist
     buildpack: paketo-buildpacks/nodejs-legacy
     routes:
       - path: /


### PR DESCRIPTION
## Summary
- explicitly point App Platform to the `dist` folder used by Vite

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c00cf384f483228634a6b8a5a30a41