### PR TITLE
chore: optimize build and deployment config

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,7 +1,7 @@
 static_sites:
   - name: theprojectarchive
     source_dir: /
-    build_command: "npm install && npm run build"
+    build_command: "npm ci && npm run build"
     # Generated assets are written to the "dist" directory by Vite.
     # Make the path explicit so the App Platform knows where to find them.
     output_dir: ./dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.env
+npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "start": "vite preview",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- reduce Docker build context with a new `.dockerignore`
- ensure reproducible DigitalOcean builds by switching to `npm ci`
- add a conventional `npm start` alias for previewing the built site

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`
- `npm start -- --help`


------
https://chatgpt.com/codex/tasks/task_e_68c0101f189c83229097a6720b3ba3cb