### PR TITLE
feat: add web server buildpack config

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -5,6 +5,9 @@ static_sites:
     # Generated assets are written to the "dist" directory by Vite.
     # Make the path explicit so the App Platform knows where to find them.
     output_dir: ./dist
-    buildpack: paketo-buildpacks/nodejs-legacy
+    buildpacks:
+      - paketo-buildpacks/nodejs-legacy
+      - paketo-buildpacks/web-servers
+    environment_slug: node-js
     routes:
       - path: /

--- a/README.md
+++ b/README.md
@@ -43,12 +43,29 @@ Optional assets can be served from a DigitalOcean Space; see `.env.example` for 
 
 ## Buildpack Deployment
 
-The site can be built and deployed using [Paketo Buildpacks](https://paketo.io/). The included `project.toml` configures the `paketo-buildpacks/nodejs-legacy` buildpack and pins Node.js to version `18.x`.
+The site can be built and deployed using [Paketo Buildpacks](https://paketo.io/). The `project.toml` configures both the Node.js runtime and an Nginx web server so the static files in `dist/` are served automatically.
 
-When deploying to platforms like DigitalOcean App Platform, the `.do/app.yaml` file specifies the build command and output directory so the built assets in `dist/` are served.
+```toml
+[[build.buildpacks]]
+id = "paketo-buildpacks/nodejs-legacy"
+
+[[build.buildpacks]]
+id = "paketo-buildpacks/web-servers"
+
+[[build.env]]
+BP_NODE_VERSION = "18.x"
+BP_WEB_SERVER = "nginx"
+BP_WEB_SERVER_ROOT = "dist"
+```
+
+When deploying to platforms like DigitalOcean App Platform, the `.do/app.yaml` file lists both buildpacks so the build image includes Nginx to serve the contents of `dist/`.
+
+The `npm start` script builds the project and serves the generated `dist/` directory using `npx serve`, enabling local preview or platforms that rely on `npm start`.
 
 ### Environment variables
 
 - `BP_NODE_VERSION` – Node runtime used during build (e.g., `18.x`).
+- `BP_WEB_SERVER` – web server to run (e.g., `nginx`).
+- `BP_WEB_SERVER_ROOT` – directory containing built assets (`dist`).
 - `NODE_ENV` – set to `production` for optimized runtime behavior.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "vite preview",
+    "start": "npm run build && npx serve -s dist",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/project.toml
+++ b/project.toml
@@ -1,5 +1,10 @@
 [[build.buildpacks]]
 id = "paketo-buildpacks/nodejs-legacy"
 
+[[build.buildpacks]]
+id = "paketo-buildpacks/web-servers"
+
 [[build.env]]
 BP_NODE_VERSION = "18.x"
+BP_WEB_SERVER = "nginx"
+BP_WEB_SERVER_ROOT = "dist"


### PR DESCRIPTION
## Summary
- serve built assets with Paketo web-servers buildpack and Nginx
- document new buildpacks and environment variables for buildpack deploys
- expose production `npm start` to build and serve `dist`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0120601e0832295b9e57709f7500c