### PR TITLE
Add animated Coming Soon page

### DIFF
--- a/comingsoon.html
+++ b/comingsoon.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Coming Soon - The Project Archive</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/comingsoon.jsx"></script>
+</body>
+</html>

--- a/src/comingsoon.jsx
+++ b/src/comingsoon.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { motion } from 'framer-motion';
+import './styles.css';
+
+function ComingSoon() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <motion.h1
+        className="text-5xl font-bold text-center"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+      >
+        Coming Soon
+      </motion.h1>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ComingSoon />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,16 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'path';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'dist',
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        comingsoon: resolve(__dirname, 'comingsoon.html'),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add Coming Soon HTML page
- animate Coming Soon message with Framer Motion
- include page in Vite build config

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c013bb6cdc8322b2a22171456364e0