### PR TITLE
Add starters section with navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import About from './components/About';
 import Mission from './components/Mission';
 import Approach from './components/Approach';
 import Numbers from './components/Numbers';
+import Starters from './components/Starters';
 import Services from './components/Services';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
@@ -50,6 +51,7 @@ export default function App() {
       <Mission />
       <Approach />
       <Numbers />
+      <Starters />
       <Services openLightbox={openLightbox} images={serviceImages} />
       <Contact />
       <Footer />

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -16,3 +16,8 @@ test('renders site header link', () => {
     screen.getByRole('link', { name: /The Project Archive/i }),
   ).toBeInTheDocument();
 });
+
+test('renders starters section', () => {
+  render(<App />);
+  expect(screen.getByRole('heading', { name: /Starters/i })).toBeInTheDocument();
+});

--- a/src/components/OverlayNav.jsx
+++ b/src/components/OverlayNav.jsx
@@ -22,6 +22,7 @@ const links = [
   { href: '#mission', label: 'Mission' },
   { href: '#approach', label: 'Approach' },
   { href: '#numbers', label: 'In Numbers' },
+  { href: '#starters', label: 'Starters' },
   { href: '#services', label: 'Services' },
   { href: '#contact', label: 'Contact' }
 ];

--- a/src/components/Starters.jsx
+++ b/src/components/Starters.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import ParallaxSection from './ParallaxSection';
+
+const textVariants = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0 },
+};
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 40 },
+  show: { opacity: 1, y: 0 },
+};
+
+export default function Starters() {
+  const starters = [
+    {
+      title: 'HTML static site starter',
+      description:
+        'Create a simple static website with control over front-end code and no dependencies.',
+    },
+    {
+      title: 'Next.js starter',
+      description:
+        'Deploy a dynamic server-rendered full-stack web app that is SEO-friendly and fast loading.',
+    },
+    {
+      title: 'Distributed job manager',
+      description:
+        'Run background jobs with a scalable queue system for data pipelines and scheduled tasks.',
+    },
+    {
+      title:
+        'Gradient Serverless Inference + Playwright MCP CUA Chat Template',
+      description:
+        'Combine serverless GPU inference with a Playwright-driven chat UI template.',
+    },
+    {
+      title: 'Dockerfile starter',
+      description:
+        'Deploy a containerized app with control over runtime and dependencies.',
+    },
+    {
+      title: 'Go starter',
+      description:
+        'Deploy a lightweight microservice, webhook, or simple backend API.',
+    },
+    {
+      title: 'Node.js starter',
+      description:
+        'Build a custom and event-driven backend service with control over server logic and dependencies.',
+    },
+    {
+      title: 'React starter',
+      description:
+        'Quickly launch a responsive single-page app with a modern frontend setup.',
+    },
+  ];
+
+  return (
+    <ParallaxSection
+      id="starters"
+      image="https://picsum.photos/1920/1080?random=26"
+      alt="Background image for Starters section"
+    >
+      <motion.h2
+        className="text-3xl font-bold mb-6"
+        variants={textVariants}
+        initial="hidden"
+        whileInView="show"
+        viewport={{ once: true, amount: 0.5 }}
+      >
+        Starters
+      </motion.h2>
+      <div className="grid gap-4 max-w-3xl mx-auto sm:grid-cols-2">
+        {starters.map((s, i) => (
+          <motion.div
+            key={i}
+            className="p-4 glass rounded text-left"
+            variants={cardVariants}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.3 }}
+          >
+            <h3 className="font-semibold text-xl mb-2">{s.title}</h3>
+            <p className="text-sm">{s.description}</p>
+          </motion.div>
+        ))}
+      </div>
+    </ParallaxSection>
+  );
+}


### PR DESCRIPTION
## Summary
- list various project starters in new Starters section
- link Starters from the overlay navigation
- test that the Starters section renders

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c10eb9949083229e7ce2c006da16c3