### PR TITLE
Use unique keys for services and starters lists

### DIFF
--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -53,7 +53,7 @@ export default function Services({ openLightbox, images = [] }) {
       <div className="mt-6 grid grid-cols-2 md:grid-cols-3 gap-4 max-w-3xl mx-auto">
         {cards.map((img, i) => (
           <motion.div
-            key={i}
+            key={img}
             className="srv-card cursor-pointer overflow-hidden rounded shadow"
             variants={cardVariants}
             initial="hidden"

--- a/src/components/Starters.jsx
+++ b/src/components/Starters.jsx
@@ -75,7 +75,7 @@ export default function Starters() {
       <div className="grid gap-4 max-w-3xl mx-auto sm:grid-cols-2">
         {starters.map((s, i) => (
           <motion.div
-            key={i}
+            key={s.title}
             className="p-4 glass rounded text-left"
             variants={cardVariants}
             initial="hidden"


### PR DESCRIPTION
## Summary
- Use image URLs as unique keys in Services cards
- Use starter titles as keys in Starters list

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1147ac0c883228d8b2f16e3c9ffc5