### PR TITLE
Add Escape key and overlay controls for lightbox

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './styles.css';
 import {
   AnimatePresence,
@@ -29,6 +29,16 @@ export default function App() {
     setLightboxOpen(true);
   };
   const closeLightbox = () => setLightboxOpen(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        closeLightbox();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [closeLightbox]);
   const { scrollY } = useScroll();
   const y = useTransform(scrollY, [0, 300], [100, 0]);
   const opacity = useTransform(scrollY, [0, 300], [0, 1]);
@@ -59,12 +69,19 @@ export default function App() {
         {lightboxOpen && (
           <motion.div
             className="lightbox"
+            role="dialog"
+            aria-modal="true"
             aria-hidden={!lightboxOpen}
             initial={{ opacity: 0, scale: 0.8 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.8 }}
+            onClick={closeLightbox}
           >
-            <img src={lightboxImg} alt="Selected service image" />
+            <img
+              src={lightboxImg}
+              alt="Selected service image"
+              onClick={(e) => e.stopPropagation()}
+            />
             <motion.button
               className="close-btn"
               aria-label="Close image"

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import App from '../App';
 import { expect, test, beforeAll } from 'vitest';
 
@@ -20,4 +20,14 @@ test('renders site header link', () => {
 test('renders starters section', () => {
   render(<App />);
   expect(screen.getByRole('heading', { name: /Starters/i })).toBeInTheDocument();
+});
+
+test('closes lightbox on Escape key', async () => {
+  render(<App />);
+  fireEvent.click(screen.getAllByAltText(/Gallery image/i)[0]);
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  fireEvent.keyDown(window, { key: 'Escape' });
+  await waitFor(() => {
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- enhance lightbox accessibility with dialog role, aria-modal and overlay click support
- close lightbox via Escape key using a new `useEffect` listener
- add test to ensure pressing Escape closes the lightbox

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1147bd2c08322a38b565dbf28d666