### PR TITLE
Add routing and NotFound page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "framer-motion": "^12.23.12",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.13",
@@ -2484,6 +2485,15 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5226,6 +5236,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5447,6 +5495,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "framer-motion": "^12.23.12",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import {
   useScroll,
   useTransform,
 } from 'framer-motion';
+import { Routes, Route } from 'react-router-dom';
 import Header from './components/Header';
 import OverlayNav from './components/OverlayNav';
 import Hero from './components/Hero';
@@ -17,8 +18,9 @@ import Starters from './components/Starters';
 import Services from './components/Services';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
+import NotFound from './components/NotFound';
 
-export default function App() {
+function Home() {
   const [navOpen, setNavOpen] = useState(false);
   const toggleNav = () => setNavOpen((o) => !o);
   const closeNav = () => setNavOpen(false);
@@ -105,5 +107,14 @@ export default function App() {
         &#8679;
       </motion.button>
     </>
+  );
+}
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
   );
 }

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
 import App from '../App';
 import { expect, test, beforeAll } from 'vitest';
 
@@ -11,19 +12,33 @@ beforeAll(() => {
 });
 
 test('renders site header link', () => {
-  render(<App />);
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+  );
   expect(
     screen.getByRole('link', { name: /The Project Archive/i }),
   ).toBeInTheDocument();
 });
 
 test('renders starters section', () => {
-  render(<App />);
-  expect(screen.getByRole('heading', { name: /Starters/i })).toBeInTheDocument();
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+  );
+  expect(
+    screen.getByRole('heading', { name: /Starters/i }),
+  ).toBeInTheDocument();
 });
 
 test('closes lightbox on Escape key', async () => {
-  render(<App />);
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+  );
   fireEvent.click(screen.getAllByAltText(/Gallery image/i)[0]);
   expect(screen.getByRole('dialog')).toBeInTheDocument();
   fireEvent.keyDown(window, { key: 'Escape' });

--- a/src/components/NotFound.jsx
+++ b/src/components/NotFound.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+
+export default function NotFound() {
+  const shouldReduceMotion = useReducedMotion();
+  const navigate = useNavigate();
+
+  return (
+    <motion.div
+      className="flex flex-col items-center justify-center min-h-screen gap-6 p-4 text-center"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: shouldReduceMotion ? 0 : 0.5 }}
+    >
+      {shouldReduceMotion ? (
+        <p className="text-xl">Page not found</p>
+      ) : (
+        <img
+          src="https://media.giphy.com/media/14uQ3cOFteDaU/giphy.gif"
+          alt="Animated loop of a confused traveler searching for a missing page"
+          className="w-64 h-64"
+        />
+      )}
+      <motion.button
+        onClick={() => navigate('/')}
+        whileHover={shouldReduceMotion ? {} : { scale: 1.05 }}
+        whileTap={shouldReduceMotion ? {} : { scale: 0.95 }}
+        className="px-4 py-2 bg-blue-500 text-white rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400"
+      >
+        Go Home
+      </motion.button>
+    </motion.div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- install and configure `react-router-dom`
- wrap app with `BrowserRouter` and declare routes with a `NotFound` fallback
- include animated NotFound component with reduced-motion support and test updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c11f87235c83228e588c5929724ba9