### PR TITLE
Improve 404 guidance and SPA fallback

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,7 @@ server {
   listen 80;
   server_name _;
   root /usr/share/nginx/html;
+  error_page 404 /index.html;
 
   gzip on;
   gzip_types text/plain text/css application/json application/javascript application/octet-stream image/svg+xml;

--- a/src/components/NotFound.jsx
+++ b/src/components/NotFound.jsx
@@ -49,8 +49,12 @@ export default function NotFound() {
           404 Not Found
         </motion.h1>
       )}
+      <p className="text-lg">
+        The page you're looking for doesn't exist. Use the button below to
+        return to the homepage.
+      </p>
       <motion.button
-        onClick={() => navigate('/')}
+        onClick={() => navigate('/', { replace: true })}
         whileHover={shouldReduceMotion ? {} : { scale: 1.05 }}
         whileTap={shouldReduceMotion ? {} : { scale: 0.95 }}
         className="px-4 py-2 bg-blue-500 text-white rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400"


### PR DESCRIPTION
## Summary
- add user guidance and replace navigation for 404 page
- configure nginx to fallback 404s to `index.html`

## Testing
- `npm run lint`
- `npm test` *(fails: Error: Failed to resolve import "react-router-dom" from "src/__tests__/App.test.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68c122fca2708322af2041d42950ab22