### PR TITLE
Use React Router links for navigation

### DIFF
--- a/src/__tests__/Header.test.jsx
+++ b/src/__tests__/Header.test.jsx
@@ -1,16 +1,25 @@
 import { render, screen } from '@testing-library/react';
 import Header from '../components/Header';
+import { BrowserRouter } from 'react-router-dom';
 import { expect, test } from 'vitest';
 import { axe } from 'vitest-axe';
 import { toHaveNoViolations } from 'vitest-axe/matchers';
 
 expect.extend({ toHaveNoViolations });
 test('menu button has accessible labels', async () => {
-  const { container, rerender } = render(<Header onToggle={() => {}} open={false} />);
+  const { container, rerender } = render(
+    <BrowserRouter>
+      <Header onToggle={() => {}} open={false} />
+    </BrowserRouter>
+  );
   expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();
   expect(await axe(container)).toHaveNoViolations();
 
-  rerender(<Header onToggle={() => {}} open={true} />);
+  rerender(
+    <BrowserRouter>
+      <Header onToggle={() => {}} open={true} />
+    </BrowserRouter>
+  );
   expect(screen.getByRole('button', { name: /close menu/i })).toBeInTheDocument();
   expect(await axe(container)).toHaveNoViolations();
 });

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { motion, useScroll, useTransform } from 'framer-motion';
 
 const topBar = {
@@ -27,7 +28,9 @@ export default function Header({ onToggle, open }) {
       animate={{ y: 0, opacity: 1 }}
       style={{ y }}
     >
-      <a href="#home" className="logo text-xl font-bold text-gray-800">The Project Archive</a>
+      <Link to="/home" className="logo text-xl font-bold text-gray-800">
+        The Project Archive
+      </Link>
       <motion.button
         className="hamburger flex flex-col justify-between w-8 h-6"
         aria-label={open ? 'Close menu' : 'Open menu'}

--- a/src/components/OverlayNav.jsx
+++ b/src/components/OverlayNav.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 
 const navVariants = {
@@ -17,15 +18,17 @@ const linkVariants = {
 };
 
 const links = [
-  { href: '#home', label: 'Home' },
-  { href: '#about', label: 'About' },
-  { href: '#mission', label: 'Mission' },
-  { href: '#approach', label: 'Approach' },
-  { href: '#numbers', label: 'In Numbers' },
-  { href: '#starters', label: 'Starters' },
-  { href: '#services', label: 'Services' },
-  { href: '#contact', label: 'Contact' }
+  { to: '/home', label: 'Home' },
+  { to: '/about', label: 'About' },
+  { to: '/mission', label: 'Mission' },
+  { to: '/approach', label: 'Approach' },
+  { to: '/numbers', label: 'In Numbers' },
+  { to: '/starters', label: 'Starters' },
+  { to: '/services', label: 'Services' },
+  { to: '/contact', label: 'Contact' }
 ];
+
+const MotionLink = motion(Link);
 
 export default function OverlayNav({ open, onLink }) {
   return (
@@ -50,15 +53,15 @@ export default function OverlayNav({ open, onLink }) {
             exit="exit"
           >
             {links.map((l) => (
-              <motion.a
-                key={l.href}
+              <MotionLink
+                key={l.to}
                 className="hover:text-red-600"
-                href={l.href}
+                to={l.to}
                 onClick={onLink}
                 variants={linkVariants}
               >
                 {l.label}
-              </motion.a>
+              </MotionLink>
             ))}
           </motion.nav>
         </>


### PR DESCRIPTION
## Summary
- Replace anchor tags with `Link` in `Header` and `OverlayNav`
- Ensure overlay navigation links close the menu when clicked
- Update Header test to render within a router context

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c122fb7de483228105cbbd1c784f8b