### PR TITLE
Add Coming Soon landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import Services from './components/Services';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
 import NotFound from './components/NotFound';
+import ComingSoon from './components/ComingSoon';
 
 function Home() {
   const [navOpen, setNavOpen] = useState(false);
@@ -54,12 +55,16 @@ function Home() {
       if (el) {
         try {
           el.scrollIntoView({ behavior: 'smooth' });
-        } catch {}
+        } catch {
+          /* empty */
+        }
       }
     } else {
       try {
         window.scrollTo({ top: 0, behavior: 'smooth' });
-      } catch {}
+      } catch {
+        /* empty */
+      }
     }
   }, [location]);
 
@@ -131,7 +136,8 @@ function Home() {
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
+      <Route path="/" element={<ComingSoon />} />
+      <Route path="/main" element={<Home />} />
       <Route path="/about" element={<Home />} />
       <Route path="/mission" element={<Home />} />
       <Route path="/approach" element={<Home />} />

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -11,7 +11,20 @@ beforeAll(() => {
   };
 });
 
-test('renders site header link', () => {
+test('renders coming soon message on root', () => {
+  window.history.pushState({}, '', '/');
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+  );
+  expect(
+    screen.getByRole('heading', { name: /coming soon/i }),
+  ).toBeInTheDocument();
+});
+
+test('renders site header link on /main', () => {
+  window.history.pushState({}, '', '/main');
   render(
     <BrowserRouter>
       <App />
@@ -22,7 +35,8 @@ test('renders site header link', () => {
   ).toBeInTheDocument();
 });
 
-test('renders starters section', () => {
+test('renders starters section on /main', () => {
+  window.history.pushState({}, '', '/main');
   render(
     <BrowserRouter>
       <App />
@@ -34,6 +48,7 @@ test('renders starters section', () => {
 });
 
 test('closes lightbox on Escape key', async () => {
+  window.history.pushState({}, '', '/main');
   render(
     <BrowserRouter>
       <App />

--- a/src/components/ComingSoon.jsx
+++ b/src/components/ComingSoon.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function ComingSoon() {
+  return (
+    <motion.main
+      className="flex flex-col items-center justify-center min-h-screen gap-6 p-4 text-center"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.5 }}
+    >
+      <motion.h1
+        className="text-4xl font-bold"
+        initial={{ y: -20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.2 }}
+      >
+        Coming Soon
+      </motion.h1>
+      <motion.p
+        className="text-lg"
+        initial={{ y: 20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.4 }}
+      >
+        Our new site is on the way. Stay tuned!
+      </motion.p>
+      <motion.div
+        className="space-y-2"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.6 }}
+      >
+        <p>
+          Contact us at{' '}
+          <a
+            href="mailto:info@theprojectarchive.com"
+            className="text-blue-500 hover:underline"
+          >
+            info@theprojectarchive.com
+          </a>
+        </p>
+        <p>
+          Call{' '}
+          <a href="tel:+9601234567" className="text-blue-500 hover:underline">
+            +960 123-4567
+          </a>
+        </p>
+      </motion.div>
+      <motion.div
+        className="flex space-x-4"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.8 }}
+      >
+        <a
+          href="https://twitter.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 hover:underline"
+        >
+          Twitter
+        </a>
+        <a
+          href="https://facebook.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 hover:underline"
+        >
+          Facebook
+        </a>
+        <a
+          href="https://instagram.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 hover:underline"
+        >
+          Instagram
+        </a>
+      </motion.div>
+    </motion.main>
+  );
+}


### PR DESCRIPTION
## Summary
- add animated ComingSoon component with contact and social links
- render ComingSoon at root path and move current site to /main
- update tests for new routing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c124f2d1e0832285f37d1992896fbc