### PR TITLE
feat: add DigitalOcean App Platform deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ GitHub Actions in `.github/workflows/deploy.yml` builds the site and deploys the
 
 Optional assets can be served from a DigitalOcean Space; see `.env.example` for configuration.
 
+### DigitalOcean App Platform
+
+Use `scripts/deploy-do-app.sh` to deploy the app to DigitalOcean App Platform with `doctl`:
+
+```bash
+./scripts/deploy-do-app.sh <environment> <access_token>
+```
+
+The script checks `DO_APP_ID_<ENV>` for an existing App Platform ID. If set, the app is updated; otherwise a new one is created using `.do/app.yaml`.
+
 ## Buildpack Deployment
 
 The site can be built and deployed using [Paketo Buildpacks](https://paketo.io/). The `project.toml` configures both the Node.js runtime and an Nginx web server so the static files in `dist/` are served automatically.

--- a/scripts/deploy-do-app.sh
+++ b/scripts/deploy-do-app.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <environment> <access_token>"
+  echo "  environment: deployment target (e.g. staging or production)"
+  echo "  access_token: DigitalOcean API token"
+}
+
+if [ "$#" -ne 2 ]; then
+  usage
+  exit 1
+fi
+
+ENVIRONMENT="$1"
+ACCESS_TOKEN="$2"
+
+export DIGITALOCEAN_ACCESS_TOKEN="$ACCESS_TOKEN"
+
+# Environment variable that holds the app ID, e.g., DO_APP_ID_PRODUCTION
+ENV_VAR="DO_APP_ID_${ENVIRONMENT^^}"
+APP_ID="${!ENV_VAR-}"
+
+CMD="doctl apps"
+SPEC="--spec .do/app.yaml"
+
+if [ -n "$APP_ID" ]; then
+  echo "Updating app $APP_ID for environment $ENVIRONMENT"
+  $CMD update "$APP_ID" $SPEC
+else
+  echo "Creating new app for environment $ENVIRONMENT"
+  $CMD create $SPEC
+fi
+


### PR DESCRIPTION
## Summary
- add `scripts/deploy-do-app.sh` to wrap `doctl` for App Platform deployments
- document DigitalOcean deployment helper in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c12e0a83b4832292e6c0a6c617d51a