### PR TITLE
fix: serve favicon via metadata

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -7,6 +7,9 @@ import Footer from '../components/Footer';
 
 export const metadata = {
   title: 'The Project Archive',
+  icons: {
+    icon: '/favicon.svg',
+  },
 };
 
 export default function RootLayout({ children }) {

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#ff0000"/>
+</svg>


### PR DESCRIPTION
## Summary
- define favicon via Next.js metadata to ensure static route
- replace binary icon with inline SVG asset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1381607508322b5dcbe976456468f