### PR TITLE
Enable CORS for cross-domain access

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,24 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET,POST,PUT,DELETE,OPTIONS',
+          },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value:
+              'Origin, X-Requested-With, Content-Type, Accept, Authorization',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,19 @@ server {
   server_name _;
   root /usr/share/nginx/html;
 
+  # Enable Cross-Origin Resource Sharing (CORS)
+  add_header 'Access-Control-Allow-Origin' '*' always;
+  add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+  add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization' always;
+
+  # Short-circuit preflight requests
+  if ($request_method = 'OPTIONS') {
+    add_header 'Access-Control-Max-Age' 86400;
+    add_header 'Content-Type' 'text/plain; charset=utf-8';
+    add_header 'Content-Length' 0;
+    return 204;
+  }
+
   gzip on;
   gzip_types text/plain text/css application/json application/javascript application/octet-stream image/svg+xml;
   gzip_min_length 256;


### PR DESCRIPTION
## Summary
- add Next.js config to set CORS headers for all routes
- configure nginx to return CORS headers and handle preflight requests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c13a32691883229314256123005b2e