### PR TITLE
Enable strict mode and document allowed origin env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Base URL for media served from DigitalOcean Spaces
 SPACE_BUCKET_URL=https://example-space.nyc3.cdn.digitaloceanspaces.com
+NEXT_ALLOWED_ORIGIN=https://theprojectarchive.com

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Install dependencies and start the development server:
 
 ```bash
 npm install
+cp .env.example .env
 npm run dev
 ```
+
+Update `NEXT_ALLOWED_ORIGIN` in `.env` if your app runs on a different URL.
 
 ## Production build
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,7 @@
 const allowedOrigin = process.env.NEXT_ALLOWED_ORIGIN ?? 'https://theprojectarchive.com';
 
 const nextConfig = {
+  reactStrictMode: true,
   images: {
     remotePatterns: [
       {
@@ -20,7 +21,7 @@ const nextConfig = {
           { key: 'Access-Control-Allow-Origin', value: allowedOrigin },
           {
             key: 'Access-Control-Allow-Methods',
-            value: 'GET,POST',
+            value: 'GET,POST,OPTIONS',
           },
           { key: 'Access-Control-Allow-Headers', value: 'Content-Type' },
         ],


### PR DESCRIPTION
## Summary
- enable React strict mode and support OPTIONS in CORS headers
- provide NEXT_ALLOWED_ORIGIN example and env setup instructions

## Testing
- `npm test` *(fails: Failed to resolve import "focus-trap" from "components/Home.jsx")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c144425ecc832285d2fba3aa5c486c