### PR TITLE
Set home page to root and drop /main route

### DIFF
--- a/app/main/page.jsx
+++ b/app/main/page.jsx
@@ -1,5 +1,0 @@
-import Home from '../../components/Home';
-
-export default function Page() {
-  return <Home />;
-}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,5 +1,5 @@
-import ComingSoon from '../components/ComingSoon';
+import Home from '../components/Home';
 
 export default function Page() {
-  return <ComingSoon />;
+  return <Home />;
 }

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -28,7 +28,7 @@ export default function Header({ onToggle, open }) {
       animate={{ y: 0, opacity: 1 }}
       style={{ y }}
     >
-      <Link href="/main" className="logo text-xl font-bold text-gray-800">
+      <Link href="/" className="logo text-xl font-bold text-gray-800">
         The Project Archive
       </Link>
       <motion.button

--- a/components/Home.jsx
+++ b/components/Home.jsx
@@ -51,7 +51,7 @@ export default function Home() {
     'scrollBehavior' in document.documentElement.style;
   useEffect(() => {
     const section = pathname.slice(1);
-    if (section && section !== 'main') {
+    if (section) {
       const el = document.getElementById(section);
       if (el) {
         try {

--- a/components/OverlayNav.jsx
+++ b/components/OverlayNav.jsx
@@ -18,7 +18,7 @@ const linkVariants = {
 };
 
 const links = [
-  { to: '/main', label: 'Home' },
+  { to: '/', label: 'Home' },
   { to: '/about', label: 'About' },
   { to: '/mission', label: 'Mission' },
   { to: '/approach', label: 'Approach' },


### PR DESCRIPTION
## Summary
- Render `Home` component directly from root `app/page.jsx`
- Remove obsolete `app/main` directory and update navigation links to `/`
- Clean up `Home` component scroll logic referencing `/main`

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c14d632bb08322bf7ad2b200575007