### PR TITLE
Add DigitalOcean deployment workflows

### DIFF
--- a/.github/workflows/delete-preview.yaml
+++ b/.github/workflows/delete-preview.yaml
@@ -1,0 +1,19 @@
+name: Delete Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DO_API_TOKEN }}
+      - name: Delete preview app
+        run: |
+          APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | awk '$2=="theprojectarchive-pr-${{ github.event.number }}" {print $1}')
+          if [ -n "$APP_ID" ]; then
+            doctl apps delete "$APP_ID" --force
+          fi

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -1,0 +1,16 @@
+name: Deploy App
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DO_API_TOKEN }}
+      - name: Deploy to DigitalOcean App Platform
+        run: ./scripts/deploy-do-app.sh production ${{ secrets.DO_API_TOKEN }}

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -1,0 +1,17 @@
+name: Deploy Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DO_API_TOKEN }}
+      - name: Deploy preview app
+        run: |
+          doctl apps create --spec <(sed "s/name: theprojectarchive/name: theprojectarchive-pr-${{ github.event.number }}/" .do/app.yaml)


### PR DESCRIPTION
## Summary
- Add GitHub workflow to deploy to DigitalOcean App Platform
- Create workflow for preview deployments on pull requests
- Delete preview environments when pull requests close

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c152d07de08322b4ff915b877230dc