### PR TITLE
docs: document App Platform output directory

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -2,6 +2,9 @@ static_sites:
   - name: theprojectarchive
     source_dir: /
     build_command: "npm ci && npm run build"
+    # The output directory is an optional path to where the build assets will be
+    # located, relative to the build context. If not set, App Platform will
+    # automatically scan for these directory names: _static, dist, public, build.
     # Next.js generates static files in the "out" directory.
     output_dir: out
     buildpacks:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Use `scripts/deploy-do-app.sh` to deploy the app to DigitalOcean App Platform wi
 
 The script checks `DO_APP_ID_<ENV>` for an existing App Platform ID. If set, the app is updated; otherwise a new one is created using `.do/app.yaml`.
 
+#### Output Directory
+
+The output directory is an optional path to where the build assets will be located,
+relative to the build context. If not set, App Platform will automatically scan for
+these directory names: `_static`, `dist`, `public`, `build`.
+
 ## Buildpack Deployment
 
 The site can be built and deployed using [Paketo Buildpacks](https://paketo.io/). The `project.toml` configures both the Node.js runtime and an Nginx web server so the static files in `out/` are served automatically.


### PR DESCRIPTION
## Summary
- document optional output directory behavior in App Platform config
- add readme note about App Platform output directory detection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c15368c0f483228a9cd28a891b90ea