### PR TITLE
Add Dockerfile for production build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage: compile Next.js app to static output
+FROM node:18-alpine AS build
+WORKDIR /app
+
+# Install dependencies
+COPY next-app/package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY next-app/ .
+RUN npm run build
+
+# Production stage: serve with nginx
+FROM nginx:alpine
+COPY --from=build /app/out /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ npm run build
 
 ## Docker
 
-Build and run the production container locally:
+A multi-stage `Dockerfile` builds the site and serves the generated `out` directory
+with Nginx. Build and run the production container locally:
 
 ```bash
+# Build the image
 docker build -t tpa-site .
-docker run -p 8080:80 tpa-site
+
+# Run the container and map port 80 to 8080 on the host
+docker run --rm -p 8080:80 tpa-site
 ```
 
 ## Deployment


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile that builds Next.js app and serves static output with nginx
- document Docker image build and run commands in README

## Testing
- `npm test --prefix next-app`
- `npm run lint --prefix next-app`

------
https://chatgpt.com/codex/tasks/task_e_68c15c8e3c148322a4426d98893a42bc