### PR TITLE
chore: update theme colors and font

### DIFF
--- a/next-app/app/globals.css
+++ b/next-app/app/globals.css
@@ -4,14 +4,14 @@
 
 :root {
   /* Colors */
-  --color-accent: #ef3c23;
-  --color-text: #333333;
-  --color-background: #f6f3e8;
+  --color-accent: #ff3d00;
+  --color-text: #070707;
+  --color-background: #373737;
   --color-surface: rgba(255, 255, 255, 0.06);
   --color-surface-border: rgba(255, 255, 255, 0.18);
   --color-background-light: #f8f9fb;
   --color-text-dark: #05192d;
-  --color-muted: #6b7280;
+  --color-muted: #909195;
   --color-card: #ffffff;
   --color-blue: #2b60ff;
   --color-pink: #ff4175;
@@ -41,7 +41,7 @@
   --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.15);
 
   /* Typography */
-  --font-sans: 'Montserrat', system-ui, sans-serif;
+  --font-sans: 'SFT Schrifted Sans', system-ui, sans-serif;
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;
   --text-base: 1rem;

--- a/next-app/tailwind.config.js
+++ b/next-app/tailwind.config.js
@@ -1,7 +1,17 @@
 export default {
   content: ['./app/**/*.{js,jsx}', './components/**/*.{js,jsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        accent: '#ff3d00',
+        text: '#070707',
+        background: '#373737',
+        muted: '#909195',
+      },
+      fontFamily: {
+        sans: ['"SFT Schrifted Sans"', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- apply SFT Schrifted Sans as default font
- refresh theme colors using #ff3d00, #070707, #373737, and #909195
- expose new palette and font in Tailwind config

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c16157b6588322b7e3fee7511f4176