### PR TITLE
Add testimonials, contact form, and footer content

### DIFF
--- a/next-app/app/globals.css
+++ b/next-app/app/globals.css
@@ -456,6 +456,15 @@ a:hover {
   color: var(--color-accent);
 }
 
+.footer-nav,
+.social-links {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
 .fade-in {
   opacity: 0;
   transform: translateY(20px);

--- a/next-app/app/layout.jsx
+++ b/next-app/app/layout.jsx
@@ -6,6 +6,8 @@ export const metadata = {
   icons: {
     icon: '/favicon.svg',
   },
+  description:
+    'Creative studio in the Maldives offering design, development, and photography services.',
 };
 
 export default function RootLayout({ children }) {

--- a/next-app/app/testimonials/page.jsx
+++ b/next-app/app/testimonials/page.jsx
@@ -1,0 +1,5 @@
+import Home from '../../components/Home';
+
+export default function Page() {
+  return <Home />;
+}

--- a/next-app/components/Contact.jsx
+++ b/next-app/components/Contact.jsx
@@ -9,6 +9,10 @@ const textVariants = {
 };
 
 export default function Contact() {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <ParallaxSection
       id="contact"
@@ -24,16 +28,44 @@ export default function Contact() {
       >
         Contact
       </motion.h2>
-      <motion.p
-        className="max-w-md mx-auto"
+      <motion.form
+        onSubmit={handleSubmit}
+        className="form max-w-md mx-auto text-left"
         variants={textVariants}
         initial="hidden"
         whileInView="show"
         viewport={{ once: true, amount: 0.5 }}
       >
-        Get in touch to discuss your project or schedule a session with our
-        team.
-      </motion.p>
+        <label htmlFor="name">Name</label>
+        <input id="name" name="name" type="text" className="input" required />
+
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          className="input"
+          required
+        />
+
+        <label htmlFor="message">Message</label>
+        <textarea
+          id="message"
+          name="message"
+          className="textarea"
+          rows="5"
+          required
+        />
+
+        <motion.button
+          type="submit"
+          className="btn btn--primary mt-2"
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+        >
+          Send Message
+        </motion.button>
+      </motion.form>
     </ParallaxSection>
   );
 }

--- a/next-app/components/Footer.jsx
+++ b/next-app/components/Footer.jsx
@@ -9,6 +9,20 @@ export default function Footer() {
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-    />
+    >
+      <p>&copy; {new Date().getFullYear()} The Project Archive</p>
+      <nav aria-label="Footer" className="footer-nav">
+        <a href="/privacy">Privacy</a>
+        <a href="/terms">Terms</a>
+      </nav>
+      <div className="social-links" aria-label="Social media links">
+        <a href="https://twitter.com" target="_blank" rel="noopener noreferrer">
+          Twitter
+        </a>
+        <a href="https://instagram.com" target="_blank" rel="noopener noreferrer">
+          Instagram
+        </a>
+      </div>
+    </motion.footer>
   );
 }

--- a/next-app/components/Home.jsx
+++ b/next-app/components/Home.jsx
@@ -17,6 +17,7 @@ import Approach from './Approach';
 import Numbers from './Numbers';
 import Starters from './Starters';
 import Services from './Services';
+import Testimonials from './Testimonials';
 import Contact from './Contact';
 
 export default function Home() {
@@ -99,6 +100,7 @@ export default function Home() {
       <Numbers />
       <Starters />
       <Services openLightbox={openLightbox} images={serviceImages} />
+      <Testimonials />
       <Contact />
       <AnimatePresence>
         {lightboxOpen && (

--- a/next-app/components/OverlayNav.jsx
+++ b/next-app/components/OverlayNav.jsx
@@ -25,6 +25,7 @@ const links = [
   { to: '/numbers', label: 'In Numbers' },
   { to: '/starters', label: 'Starters' },
   { to: '/services', label: 'Services' },
+  { to: '/testimonials', label: 'Testimonials' },
   { to: '/contact', label: 'Contact' }
 ];
 

--- a/next-app/components/Testimonials.jsx
+++ b/next-app/components/Testimonials.jsx
@@ -1,0 +1,58 @@
+"use client";
+import { motion } from 'framer-motion';
+import ParallaxSection from './ParallaxSection';
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0 },
+};
+
+export default function Testimonials() {
+  const testimonials = [
+    {
+      quote: 'The team captured our vision perfectly and delivered beyond expectations.',
+      author: 'Aisha R.',
+    },
+    {
+      quote: 'Professional, creative, and a pleasure to work with from start to finish.',
+      author: 'Luca M.',
+    },
+    {
+      quote: 'Their attention to detail made our project shine.',
+      author: 'Sara T.',
+    },
+  ];
+
+  return (
+    <ParallaxSection
+      id="testimonials"
+      image="https://picsum.photos/1920/1080?random=40"
+      alt="Background image for Testimonials section"
+    >
+      <motion.h2
+        className="text-3xl font-bold mb-8"
+        variants={cardVariants}
+        initial="hidden"
+        whileInView="show"
+        viewport={{ once: true, amount: 0.5 }}
+      >
+        Testimonials
+      </motion.h2>
+      <div className="testimonials-grid mt-8 text-left">
+        {testimonials.map((t, idx) => (
+          <motion.figure
+            key={idx}
+            className="testimonial-card"
+            variants={cardVariants}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.3 }}
+          >
+            <blockquote>“{t.quote}”</blockquote>
+            <figcaption>— {t.author}</figcaption>
+          </motion.figure>
+        ))}
+      </div>
+    </ParallaxSection>
+  );
+}


### PR DESCRIPTION
## Summary
- Implement testimonials section with parallax background and navigation link
- Replace contact placeholder with accessible form
- Populate footer with site links and social profiles and add meta description

## Testing
- `npm test`
- `npm run build`
- `npm start` (manually terminated)


------
https://chatgpt.com/codex/tasks/task_e_68c1650e2f848322b512e4060c94c3cf