### PR TITLE
chore: stream nginx logs to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN npm run build
 # Production stage: serve with nginx
 FROM nginx:alpine
 COPY --from=build /app/out /usr/share/nginx/html
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["sh", "-c", "echo Starting Nginx to serve static assets && nginx -g 'daemon off;'"]


### PR DESCRIPTION
## Summary
- symlink Nginx access and error logs to stdout/stderr
- log a startup message before launching Nginx

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1836683a88322b273459746ac0440