### PR TITLE
Add maintenance mode and coming soon page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ cp .env.example .env
 npm run dev
 ```
 
-Update `NEXT_ALLOWED_ORIGIN` and `SPACE_BUCKET_URL` in `.env` to match your environment.
+Update `NEXT_ALLOWED_ORIGIN`, `SPACE_BUCKET_URL`, and `MAINTENANCE_MODE` in `.env` to match your environment.
+
+## Maintenance mode
+
+Set `MAINTENANCE_MODE=true` to redirect all traffic to `/coming-soon`. The middleware in `next-app/middleware.ts` reads `process.env.MAINTENANCE_MODE`, similar to how `next-app/next.config.mjs` uses `SPACE_BUCKET_URL`.
 
 ## Design Tokens
 
@@ -125,6 +129,7 @@ The `npm start` script runs the Next.js server for local preview.
 - `BP_WEB_SERVER` – web server to run (e.g., `nginx`).
 - `BP_WEB_SERVER_ROOT` – directory containing built assets (`out`).
 - `NODE_ENV` – set to `production` for optimized runtime behavior.
+- `MAINTENANCE_MODE` – set to `true` to redirect users to `/coming-soon`.
 
 ## Accessibility
 

--- a/next-app/.env
+++ b/next-app/.env
@@ -1,3 +1,5 @@
 # Base URL for media served from DigitalOcean Spaces
 SPACE_BUCKET_URL=https://theprojectarchives-4ud4t.ondigitalocean.app/
 NEXT_ALLOWED_ORIGIN=https://theprojectarchive.com
+# Redirect all traffic to the coming soon page when true
+MAINTENANCE_MODE=false

--- a/next-app/app/coming-soon/page.jsx
+++ b/next-app/app/coming-soon/page.jsx
@@ -1,0 +1,5 @@
+import ComingSoon from '../../components/ComingSoon';
+
+export default function Page() {
+  return <ComingSoon />;
+}

--- a/next-app/middleware.ts
+++ b/next-app/middleware.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  if (process.env.MAINTENANCE_MODE === 'true') {
+    return NextResponse.redirect(new URL('/coming-soon', request.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/|coming-soon|favicon.ico).*)'],
+};


### PR DESCRIPTION
## Summary
- add `/coming-soon` route backed by existing ComingSoon component
- redirect traffic to coming soon page when `MAINTENANCE_MODE=true`
- document maintenance mode and sample env var

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1a52fe324832284613d8bf9cb7641