### PR TITLE
Ensure buildpack can find static assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ node_modules/
 out/
 dist/
 dist-ssr/
-_static/
 *.local

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Spacing, radii, typography, and color tokens are defined as CSS custom propertie
 
 ## Production build
 
-Create an optimized production build in the `out` folder. The resulting `_static` directory is generated from `out/` and is excluded from version control:
+Create an optimized production build in the repository's `out` folder, which is excluded from version control:
 
 ```bash
 npm run build
 ```
 
-To rebuild automatically when files in `app/` change and refresh the local `_static` directory:
+To rebuild automatically when files in `app/` change and refresh the local `out/` directory:
 
 ```bash
 npm run watch-static
@@ -79,8 +79,8 @@ The script checks `DO_APP_ID_<ENV>` for an existing App Platform ID. If set, the
 #### Output Directory
 
 The output directory is an optional path to where the build assets will be located,
-relative to the build context. If not set, App Platform will automatically scan for
-these directory names: `_static`, `dist`, `public`, `build`.
+relative to the build context. This project writes its static build to `out/`. If not set,
+App Platform will automatically scan for these directory names: `_static`, `dist`, `public`, `build`.
 
 ### Kubernetes
 

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build && npm run sync-static",
-    "start": "npx -y serve@latest out",
+    "start": "npx -y serve@latest ../out",
     "test": "vitest run",
     "lint": "eslint . --ext js,jsx,mjs --no-error-on-unmatched-pattern",
     "format": "prettier . --write",

--- a/next-app/scripts/update-static.mjs
+++ b/next-app/scripts/update-static.mjs
@@ -9,7 +9,9 @@ const __dirname = path.dirname(__filename);
 const projectDir = path.resolve(__dirname, '..');
 const buildDir = path.join(projectDir, '.next');
 const outDir = path.join(projectDir, 'out');
-const targetDir = path.resolve(projectDir, '..', '_static');
+// Copy the static build output to the repository root so the buildpack can
+// serve it via the web server configured in project.toml.
+const targetDir = path.resolve(projectDir, '..', 'out');
 
 if (!existsSync(buildDir)) {
   console.log('Running next build...');


### PR DESCRIPTION
## Summary
- Copy Next.js export to repository `out` directory for buildpack serving
- Serve root `out` dir in start script and cleanup `.gitignore`
- Document `out/` as the build output location

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1edf70aa08322a8d969020964a43b