### PR TITLE
Align build output directory with platform expectations

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -5,8 +5,8 @@ static_sites:
     # The output directory is an optional path to where the build assets will be
     # located, relative to the build context. If not set, App Platform will
     # automatically scan for these directory names: _static, dist, public, build.
-    # Next.js generates static files in the "out" directory.
-    output_dir: out
+    # The build script outputs static files to the "build" directory.
+    output_dir: build
     buildpacks:
       - paketo-buildpacks/nodejs-legacy
       - paketo-buildpacks/web-servers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  BUILD_DIR: _static
+  BUILD_DIR: build
 
 jobs:
   lint-and-test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .next/
 out/
+build/
 dist/
 dist-ssr/
 *.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 
 # Production stage: serve with nginx
 FROM nginx:alpine
-COPY --from=build /app/out /usr/share/nginx/html
+COPY --from=build /build /usr/share/nginx/html
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Spacing, radii, typography, and color tokens are defined as CSS custom propertie
 
 ## Production build
 
-Create an optimized production build in the repository's `out` folder, which is excluded from version control:
+Create an optimized production build in the repository's `build` folder, which is excluded from version control:
 
 ```bash
 npm run build
 ```
 
-To rebuild automatically when files in `app/` change and refresh the local `out/` directory:
+To rebuild automatically when files in `app/` change and refresh the local `build/` directory:
 
 ```bash
 npm run watch-static
@@ -44,7 +44,7 @@ The hero section showcases a rotating 3D cube using `three` and `@react-three/fi
 
 ## Docker
 
-A multi-stage `Dockerfile` builds the site and serves the generated `out` directory
+A multi-stage `Dockerfile` builds the site and serves the generated `build` directory
 with Nginx. Build and run the production container locally:
 
 ```bash
@@ -57,7 +57,7 @@ docker run --rm -p 8080:80 tpa-site
 
 ## Deployment
 
-GitHub Actions in `.github/workflows/deploy.yml` builds the site and deploys the `out/` directory to a DigitalOcean Droplet via SCP. Configure the following secrets in your repository settings:
+GitHub Actions in `.github/workflows/deploy.yml` builds the site and deploys the `build/` directory to a DigitalOcean Droplet via SCP. Configure the following secrets in your repository settings:
 
 - `DO_SSH_HOST` – Droplet IP or hostname
 - `DO_SSH_USER` – SSH user
@@ -79,7 +79,7 @@ The script checks `DO_APP_ID_<ENV>` for an existing App Platform ID. If set, the
 #### Output Directory
 
 The output directory is an optional path to where the build assets will be located,
-relative to the build context. This project writes its static build to `out/`. If not set,
+relative to the build context. This project writes its static build to `build/`. If not set,
 App Platform will automatically scan for these directory names: `_static`, `dist`, `public`, `build`.
 
 ### Kubernetes
@@ -100,7 +100,7 @@ The workflow `.github/workflows/deploy-k8s.yml` automates this process. Configur
 
 ## Buildpack Deployment
 
-The site can be built and deployed using [Paketo Buildpacks](https://paketo.io/). The `project.toml` configures both the Node.js runtime and an Nginx web server so the static files in `out/` are served automatically.
+The site can be built and deployed using [Paketo Buildpacks](https://paketo.io/). The `project.toml` configures both the Node.js runtime and an Nginx web server so the static files in `build/` are served automatically.
 
 ```toml
 [[build.buildpacks]]
@@ -112,10 +112,10 @@ id = "paketo-buildpacks/web-servers"
 [[build.env]]
 BP_NODE_VERSION = "18.x"
 BP_WEB_SERVER = "nginx"
-BP_WEB_SERVER_ROOT = "out"
+BP_WEB_SERVER_ROOT = "build"
 ```
 
-When deploying to platforms like DigitalOcean App Platform, the `.do/app.yaml` file lists both buildpacks so the build image includes Nginx to serve the contents of `out/`.
+When deploying to platforms like DigitalOcean App Platform, the `.do/app.yaml` file lists both buildpacks so the build image includes Nginx to serve the contents of `build/`.
 
 The `npm start` script runs the Next.js server for local preview.
 
@@ -123,7 +123,7 @@ The `npm start` script runs the Next.js server for local preview.
 
 - `BP_NODE_VERSION` – Node runtime used during build (e.g., `18.x`).
 - `BP_WEB_SERVER` – web server to run (e.g., `nginx`).
-- `BP_WEB_SERVER_ROOT` – directory containing built assets (`out`).
+- `BP_WEB_SERVER_ROOT` – directory containing built assets (`build`).
 - `NODE_ENV` – set to `production` for optimized runtime behavior.
 - `MAINTENANCE_MODE` – set to `true` to redirect users to `/coming-soon`.
 


### PR DESCRIPTION
## Summary
- Serve static assets from the `build` directory across Docker, GitHub Actions, and App Platform configs
- Document `build` as the output path and ignore built files

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1f2ff6bfc8322a0b134668e4f129b