### PR TITLE
Simplify static build step

### DIFF
--- a/next-app/package.json
+++ b/next-app/package.json
@@ -5,12 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build && npm run sync-static",
+    "build": "node scripts/update-static.mjs",
     "start": "npx -y serve@latest ../build",
     "test": "vitest run",
     "lint": "eslint . --ext js,jsx,mjs --no-error-on-unmatched-pattern",
     "format": "prettier . --write",
-    "sync-static": "node scripts/update-static.mjs",
     "watch-static": "chokidar \"app/**\" -c \"npm run build\""
   },
   "keywords": [],

--- a/next-app/scripts/update-static.mjs
+++ b/next-app/scripts/update-static.mjs
@@ -7,16 +7,13 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectDir = path.resolve(__dirname, '..');
-const buildDir = path.join(projectDir, '.next');
 const outDir = path.join(projectDir, 'out');
 // Copy the static build output to the repository root so the buildpack can
 // serve it via the web server configured in project.toml.
 const targetDir = path.resolve(projectDir, '..', 'build');
 
-if (!existsSync(buildDir)) {
-  console.log('Running next build...');
-  execSync('next build', { cwd: projectDir, stdio: 'inherit' });
-}
+console.log('Running next build...');
+execSync('next build', { cwd: projectDir, stdio: 'inherit' });
 
 if (!existsSync(outDir)) {
   throw new Error('Missing out directory; ensure next.config.js sets output: "export"');

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
     "postinstall": "npm --prefix next-app install",
     "dev": "npm --prefix next-app run dev",
     "build": "npm --prefix next-app run build",
-    "start": "npx -y serve@latest build",
+    "start": "npm --prefix next-app run start",
     "test": "npm --prefix next-app run test",
     "lint": "npm --prefix next-app run lint",
     "format": "npm --prefix next-app run format",
-    "sync-static": "npm --prefix next-app run sync-static",
     "watch-static": "npm --prefix next-app run watch-static"
   }
 }


### PR DESCRIPTION
## Summary
- streamline Next.js static build by consolidating build and copy logic into one script
- remove redundant sync-static scripts in root and app packages
- delegate root start script to app package so `npm start` serves the repository's `build` output

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1fbcf8b588322a27a049bf8922b69