### PR TITLE
Improve overlay navigation accessibility

### DIFF
--- a/next-app/components/Header.jsx
+++ b/next-app/components/Header.jsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { motion, useScroll, useTransform } from 'framer-motion';
@@ -43,7 +43,7 @@ export default function Header({ onToggle, open }) {
         boxShadow: 'var(--shadow-1)',
         zIndex: 'var(--z-sticky)',
         color: 'var(--text)',
-        y
+        y,
       }}
       initial={{ y: -20, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
@@ -51,7 +51,9 @@ export default function Header({ onToggle, open }) {
       <Link href="/" style={{ fontSize: 'var(--fs-2)', fontWeight: 750 }}>
         The Project Archive
       </Link>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)' }}>
+      <div
+        style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)' }}
+      >
         {mounted && (
           <button
             onClick={toggleTheme}
@@ -67,16 +69,38 @@ export default function Header({ onToggle, open }) {
             flexDirection: 'column',
             justifyContent: 'space-between',
             width: '2rem',
-            height: '1.5rem'
+            height: '1.5rem',
           }}
+          type="button"
           aria-label={open ? 'Close menu' : 'Open menu'}
           onClick={onToggle}
           initial={false}
           animate={open ? 'open' : 'closed'}
         >
-          <motion.span style={{ display: 'block', height: '2px', background: 'var(--text)' }} variants={topBar}></motion.span>
-          <motion.span style={{ display: 'block', height: '2px', background: 'var(--text)' }} variants={middleBar}></motion.span>
-          <motion.span style={{ display: 'block', height: '2px', background: 'var(--text)' }} variants={bottomBar}></motion.span>
+          <motion.span
+            style={{
+              display: 'block',
+              height: '2px',
+              background: 'var(--text)',
+            }}
+            variants={topBar}
+          ></motion.span>
+          <motion.span
+            style={{
+              display: 'block',
+              height: '2px',
+              background: 'var(--text)',
+            }}
+            variants={middleBar}
+          ></motion.span>
+          <motion.span
+            style={{
+              display: 'block',
+              height: '2px',
+              background: 'var(--text)',
+            }}
+            variants={bottomBar}
+          ></motion.span>
         </motion.button>
       </div>
     </motion.header>

--- a/next-app/components/Home.jsx
+++ b/next-app/components/Home.jsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import { useState, useEffect, useRef } from 'react';
 import {
   AnimatePresence,
@@ -30,6 +30,7 @@ export default function Home() {
   const closeLightbox = () => setLightboxOpen(false);
 
   useEffect(() => {
+    if (!lightboxOpen) return;
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') {
         closeLightbox();
@@ -37,7 +38,7 @@ export default function Home() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [lightboxOpen]);
 
   const { scrollY } = useScroll();
   const y = useTransform(scrollY, [0, 300], [100, 0]);
@@ -55,14 +56,19 @@ export default function Home() {
       const el = document.getElementById(section);
       if (el) {
         try {
-          el.scrollIntoView({ behavior: supportsSmoothScroll ? 'smooth' : 'auto' });
+          el.scrollIntoView({
+            behavior: supportsSmoothScroll ? 'smooth' : 'auto',
+          });
         } catch (err) {
           console.error('Scroll into view failed', err);
         }
       }
     } else {
       try {
-        window.scrollTo({ top: 0, behavior: supportsSmoothScroll ? 'smooth' : 'auto' });
+        window.scrollTo({
+          top: 0,
+          behavior: supportsSmoothScroll ? 'smooth' : 'auto',
+        });
       } catch (err) {
         console.error('Scroll to top failed', err);
       }
@@ -111,7 +117,7 @@ export default function Home() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              zIndex: 'var(--z-modal)'
+              zIndex: 'var(--z-modal)',
             }}
             role="dialog"
             aria-modal="true"
@@ -142,7 +148,7 @@ export default function Home() {
                 color: 'var(--text)',
                 display: 'flex',
                 alignItems: 'center',
-                justifyContent: 'center'
+                justifyContent: 'center',
               }}
               aria-label="Close image"
               onClick={closeLightbox}
@@ -167,7 +173,7 @@ export default function Home() {
           color: 'var(--text)',
           boxShadow: 'var(--shadow-1)',
           y,
-          opacity
+          opacity,
         }}
         aria-label="Scroll to top"
         onClick={() =>

--- a/next-app/components/OverlayNav.jsx
+++ b/next-app/components/OverlayNav.jsx
@@ -1,6 +1,8 @@
-"use client";
+'use client';
 import Link from 'next/link';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useRef } from 'react';
+import { createFocusTrap } from 'focus-trap';
 
 const navVariants = {
   hidden: { y: -30, opacity: 0 },
@@ -25,17 +27,43 @@ const links = [
   { to: '/numbers', label: 'In Numbers' },
   { to: '/services', label: 'Services' },
   { to: '/testimonials', label: 'Testimonials' },
-  { to: '/contact', label: 'Contact' }
+  { to: '/contact', label: 'Contact' },
 ];
 
 export default function OverlayNav({ open, onLink }) {
+  const trapRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const trap = createFocusTrap(trapRef.current, {
+      fallbackFocus: trapRef.current,
+    });
+    trap.activate();
+    return () => trap.deactivate();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onLink();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [open, onLink]);
+
   return (
     <AnimatePresence>
       {open && (
-        <>
+        <div ref={trapRef}>
           <motion.div
             key="backdrop"
-            style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)' }}
+            style={{
+              position: 'fixed',
+              inset: 0,
+              background: 'rgba(0,0,0,0.5)',
+            }}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -53,7 +81,7 @@ export default function OverlayNav({ open, onLink }) {
               gap: 'var(--space-5)',
               fontSize: 'var(--fs-3)',
               fontWeight: 750,
-              textAlign: 'center'
+              textAlign: 'center',
             }}
             aria-hidden={!open}
             variants={navVariants}
@@ -69,7 +97,7 @@ export default function OverlayNav({ open, onLink }) {
               </motion.span>
             ))}
           </motion.nav>
-        </>
+        </div>
       )}
     </AnimatePresence>
   );


### PR DESCRIPTION
## Summary
- trap keyboard focus and close on Escape in overlay nav
- register Escape handler only while lightbox open
- declare menu toggle button type

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c20df19cf883229dc3e98960f0f23c