### PR TITLE
feat: add brand 3D button

### DIFF
--- a/next-app/components/Button.jsx
+++ b/next-app/components/Button.jsx
@@ -11,12 +11,12 @@ export default function Button({
 }) {
   const reduceMotion = useReducedMotion();
   const Component = href ? motion.a : motion.button;
-  const variantClass =
-    variant === 'primary'
-      ? 'button button--primary'
-      : variant === 'danger'
-        ? 'button button--danger'
-        : 'button';
+  const variants = {
+    primary: 'button button--primary',
+    danger: 'button button--danger',
+    brand3d: 'button button--3d',
+  };
+  const variantClass = variants[variant] ?? 'button';
   return (
     <Component
       href={href}

--- a/next-app/components/Hero.jsx
+++ b/next-app/components/Hero.jsx
@@ -188,7 +188,7 @@ export default function Hero() {
         >
           <Button
             href="#contact"
-            variant="primary"
+            variant="brand3d"
             variants={itemDown(reduceMotion)}
           >
             Contact Us

--- a/next-app/styles/globals.css
+++ b/next-app/styles/globals.css
@@ -53,6 +53,26 @@ a:hover { opacity: .9; }
 .button:hover { transform: translateY(-1px); background: color-mix(in oklab, var(--surface), white 3%); }
 .button--primary { background: var(--brand-500); border-color: transparent; color: #fff; }
 .button--danger  { background: var(--error); border-color: transparent; color: #fff; }
+.button--3d {
+  position: relative;
+  background: var(--brand-500);
+  border-color: transparent;
+  color: #fff;
+  transform-style: preserve-3d;
+}
+.button--3d::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: color-mix(in oklab, var(--brand-500), black 15%);
+  transform: translate3d(0, 4px, -1px);
+  transition: transform var(--dur-1) var(--ease-std);
+}
+.button--3d:hover { transform: translateY(-2px); }
+.button--3d:hover::before { transform: translate3d(0, 6px, -1px); }
+.button--3d:active { transform: translateY(0); }
+.button--3d:active::before { transform: translate3d(0, 2px, -1px); }
 .compact-email-button {
   width: 3rem;
   height: 3rem;


### PR DESCRIPTION
## Summary
- add brand-themed 3D button style
- support new 3D button variant in Button component
- showcase 3D CTA in hero section

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4b3b109d08322acfbb199d99fc116