### PR TITLE
style: refine landing page layout for mobile

### DIFF
--- a/next-app/components/ChatWidget.jsx
+++ b/next-app/components/ChatWidget.jsx
@@ -30,14 +30,14 @@ export default function ChatWidget() {
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        bottom: '1rem',
-        right: '1rem',
-        zIndex: 1000,
-      }}
-    >
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 'var(--space-5)',
+          right: 'var(--space-5)',
+          zIndex: 1000,
+        }}
+      >
       <AnimatePresence initial={false} mode="wait">
         {open ? (
           <motion.div

--- a/next-app/components/Hero.jsx
+++ b/next-app/components/Hero.jsx
@@ -60,8 +60,10 @@ export default function Hero() {
       style={{
         minHeight: '100dvh',
         display: 'flex',
+        flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: 'var(--space-8)',
         textAlign: 'center',
         position: 'relative',
         y: reduceMotion ? 0 : y,
@@ -97,18 +99,14 @@ export default function Hero() {
         }}
       />
       <div
-        className="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8"
+        className="mx-auto glass card"
         style={{
           position: 'relative',
           zIndex: 10,
-          background: 'color-mix(in oklab, var(--bg), transparent 50%)',
-          padding: 'var(--space-5)',
-          borderRadius: 'var(--radius-md)',
           maxWidth: '36rem',
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          justifyContent: 'center',
           textAlign: 'center',
         }}
       >
@@ -184,21 +182,31 @@ export default function Hero() {
           }}
           variants={ctaContainer}
         >
-          <Button
-            href="#contact"
-            variant="brand3d"
-            variants={itemDown(reduceMotion)}
-          >
-            Contact Us
-          </Button>
-          <Button
-            href="#services"
-            variant="secondary"
-            variants={itemDown(reduceMotion)}
-          >
-            Explore Portfolio
-          </Button>
-        </motion.div>
+            <Button
+              href="#contact"
+              variant="brand3d"
+              variants={itemDown(reduceMotion)}
+              style={{
+                fontSize: 'var(--fs-1)',
+                padding: 'var(--space-3) var(--space-6)',
+                fontWeight: 600,
+              }}
+            >
+              Contact Us
+            </Button>
+            <Button
+              href="#services"
+              variant="primary"
+              variants={itemDown(reduceMotion)}
+              style={{
+                fontSize: 'var(--fs-1)',
+                padding: 'var(--space-3) var(--space-6)',
+                fontWeight: 600,
+              }}
+            >
+              Explore Portfolio
+            </Button>
+          </motion.div>
       </div>
     </motion.section>
   );

--- a/next-app/components/ParallaxSection.jsx
+++ b/next-app/components/ParallaxSection.jsx
@@ -42,7 +42,7 @@ export default function ParallaxSection({
     <motion.section
       id={id}
       ref={ref}
-      className="scroll-mt-header relative flex min-h-[100dvh] items-center justify-center overflow-hidden"
+      className="scroll-mt-header relative flex min-h-[80dvh] md:min-h-[90dvh] lg:min-h-[100dvh] items-center justify-center overflow-hidden py-16"
       initial={{ opacity: 0 }}
       whileInView={{ opacity: 1 }}
       viewport={{ once: true, amount: 0.5 }}
@@ -77,11 +77,8 @@ export default function ParallaxSection({
         />
       )}
       <motion.div
-        className="relative z-20 p-[var(--space-6)] rounded-[var(--radius-md)] text-center"
-        style={{
-          background: 'color-mix(in oklab, var(--surface), transparent 30%)',
-          backdropFilter: 'blur(8px)'
-        }}
+        className="relative z-20 text-center glass card"
+        style={{ maxWidth: '36rem', marginInline: 'auto' }}
         initial={{ opacity: 0, y: reduceMotion ? 0 : 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, amount: 0.5 }}


### PR DESCRIPTION
## Summary
- move hero content near the top and apply consistent glass card styling
- tighten parallax section spacing and unify cards across sections
- reposition chat widget with standard spacing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4bdac28dc8322ba17350be5bc20f8