### PR TITLE
feat: enhance hero with bidirectional ticker and mascot

### DIFF
--- a/next-app/components/CurvedLoopText.jsx
+++ b/next-app/components/CurvedLoopText.jsx
@@ -28,7 +28,7 @@ import {
   },
   direction = 'left',
   baseVelocity = 50,
-  curveAmount = 300,
+  curveAmount = 200,
   draggable = true,
   fade = true,
 }) {
@@ -52,7 +52,7 @@ import {
   const pathId = `curve-${staticId}`;
   const fadeGradientId = `fadeGradient-${staticId}`;
   const fadeMaskId = `fadeMask-${staticId}`;
-  const pathD = `M-100,400 Q720,${400 + curveAmount} 1540,400`;
+  const pathD = `M0,300 Q500,${300 - curveAmount} 1000,300`;
   const defaultVelocity = useMotionValue(1);
   const isDragging = useRef(false);
   const dragVelocity = useRef(0);
@@ -164,15 +164,17 @@ import {
     onHoverEnd: () => (isHovered.current = false),
     style: {
       visibility: ready ? 'visible' : 'hidden',
-      minHeight: '100vh',
       width: '100%',
       height: '100%',
+      position: 'absolute',
+      top: 0,
+      left: 0,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
     },
     children: /*#__PURE__*/ _jsxs('svg', {
-      viewBox: '0 0 1440 800',
+      viewBox: '0 0 1000 600',
       style: {
         position: 'absolute',
         top: '50%',
@@ -180,7 +182,7 @@ import {
         transform: 'translate(-50%, -50%)',
         userSelect: 'none',
         width: '100%',
-        aspectRatio: '1440 / 800',
+        aspectRatio: '1000 / 600',
         overflow: 'visible',
         display: 'block',
         fill: text.color,

--- a/next-app/components/Hero.jsx
+++ b/next-app/components/Hero.jsx
@@ -51,6 +51,7 @@ export default function Hero() {
     offset: ['start start', 'end start'],
   });
   const y = useTransform(scrollYProgress, [0, 1], [0, -100]);
+  const catOpacity = useTransform(scrollYProgress, [0, 0.5, 1], [0, 1, 0]);
 
   return (
     <motion.section
@@ -98,6 +99,21 @@ export default function Hero() {
           zIndex: 1,
         }}
       />
+      <motion.div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          fontSize: '4rem',
+          zIndex: 5,
+          opacity: reduceMotion ? 1 : catOpacity,
+          pointerEvents: 'none',
+        }}
+      >
+        🐱
+      </motion.div>
       <div
         className="mx-auto glass card"
         style={{
@@ -110,6 +126,19 @@ export default function Hero() {
           textAlign: 'center',
         }}
       >
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: "url('/paw-print.svg')",
+            backgroundRepeat: 'repeat',
+            backgroundSize: '40px 40px',
+            opacity: 0.1,
+            pointerEvents: 'none',
+            zIndex: -1,
+          }}
+        />
         <motion.h1
           style={{
             color: 'var(--brand-500)',
@@ -124,7 +153,13 @@ export default function Hero() {
           {HERO_TITLE}
         </motion.h1>
         <motion.div
-          style={{ marginBottom: 'var(--space-4)' }}
+          style={{
+            marginBottom: 'var(--space-4)',
+            position: 'relative',
+            height: '6rem',
+            width: '100%',
+            overflow: 'hidden',
+          }}
           variants={itemUp(reduceMotion)}
           aria-hidden="true"
         >
@@ -142,22 +177,40 @@ export default function Hero() {
               {HERO_TAGLINE}
             </span>
           ) : (
-            <CurvedLoop
-              text={{
-                text: HERO_TAGLINE,
-                font: {
-                  fontFamily: 'var(--font-sans)',
-                  fontWeight: '600',
-                  fontSize: 24,
-                },
-                color: 'var(--brand-500)',
-              }}
-              direction="left"
-              baseVelocity={50}
-              curveAmount={300}
-              draggable={false}
-              fade={false}
-            />
+            <>
+              <CurvedLoop
+                text={{
+                  text: HERO_TAGLINE,
+                  font: {
+                    fontFamily: 'var(--font-sans)',
+                    fontWeight: '600',
+                    fontSize: 24,
+                  },
+                  color: 'var(--brand-500)',
+                }}
+                direction="left"
+                baseVelocity={50}
+                curveAmount={200}
+                draggable={false}
+                fade={false}
+              />
+              <CurvedLoop
+                text={{
+                  text: HERO_TAGLINE,
+                  font: {
+                    fontFamily: 'var(--font-sans)',
+                    fontWeight: '600',
+                    fontSize: 24,
+                  },
+                  color: 'var(--brand-500)',
+                }}
+                direction="right"
+                baseVelocity={50}
+                curveAmount={-200}
+                draggable={false}
+                fade={false}
+              />
+            </>
           )}
         </motion.div>
         <Hero3D />

--- a/next-app/public/paw-print.svg
+++ b/next-app/public/paw-print.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="black">
+  <circle cx="20" cy="20" r="12"/>
+  <circle cx="50" cy="15" r="12"/>
+  <circle cx="80" cy="20" r="12"/>
+  <path d="M50 40c-20 0-30 20-30 30s10 20 30 20 30-10 30-20-10-30-30-30z"/>
+</svg>


### PR DESCRIPTION
## Summary
- animate cat mascot logo that fades in and out while scrolling
- add faint paw-print background pattern to hero card
- replace curve path and render bidirectional curved tickers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c46022a48322929c70c7a245a0f7