### PR TITLE
feat: enhance desktop landing layout

### DIFF
--- a/next-app/components/Approach.jsx
+++ b/next-app/components/Approach.jsx
@@ -32,28 +32,11 @@ export default function Approach() {
       description="We combine technical expertise with artistic vision to craft memorable imagery."
     >
       <ol
-        style={{
-          display: 'grid',
-          gap: 'var(--space-4)',
-          marginTop: 'var(--space-6)',
-          textAlign: 'left',
-          maxWidth: '32rem',
-          marginInline: 'auto'
-        }}
+        className="mt-6 grid grid-cols-1 gap-4 text-left mx-auto w-full max-w-3xl md:max-w-5xl md:grid-cols-3"
       >
         {steps.map(({ icon, title, text }) => (
-          <li
-            key={title}
-            style={{
-              display: 'flex',
-              gap: 'var(--space-3)',
-              alignItems: 'flex-start'
-            }}
-          >
-            <span
-              aria-hidden="true"
-              style={{ fontSize: 'var(--fs-3)' }}
-            >
+          <li key={title} className="flex items-start gap-3">
+            <span aria-hidden="true" className="text-[var(--fs-3)]">
               {icon}
             </span>
             <span>

--- a/next-app/components/Contact.jsx
+++ b/next-app/components/Contact.jsx
@@ -60,69 +60,75 @@ export default function Contact() {
     >
       <motion.form
         onSubmit={handleSubmit(onSubmit)}
-        style={{ maxWidth: '32rem', marginInline: 'auto', textAlign: 'left' }}
+        className="mx-auto w-full max-w-3xl lg:max-w-5xl text-left grid gap-4 md:grid-cols-2"
         variants={textVariants(reduceMotion)}
         initial="hidden"
         whileInView="show"
         viewport={{ once: true, amount: 0.5 }}
       >
-        <label htmlFor="name">Name</label>
-        <input
-          id="name"
-          type="text"
-          {...register('name', { onChange: () => setStatus(null) })}
-          aria-invalid={!!errors.name}
-          aria-describedby="name-error"
-          required
-          autoComplete="name"
-        />
-        <span id="name-error" className="error-text">
-          {errors.name?.message}
-        </span>
+        <div className="flex flex-col">
+          <label htmlFor="name">Name</label>
+          <input
+            id="name"
+            type="text"
+            {...register('name', { onChange: () => setStatus(null) })}
+            aria-invalid={!!errors.name}
+            aria-describedby="name-error"
+            required
+            autoComplete="name"
+          />
+          <span id="name-error" className="error-text">
+            {errors.name?.message}
+          </span>
+        </div>
 
-        <label htmlFor="email">Email</label>
-        <input
-          id="email"
-          type="email"
-          {...register('email', { onChange: () => setStatus(null) })}
-          aria-invalid={!!errors.email}
-          aria-describedby="email-error"
-          required
-          autoComplete="email"
-        />
-        <span id="email-error" className="error-text">
-          {errors.email?.message}
-        </span>
+        <div className="flex flex-col">
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            {...register('email', { onChange: () => setStatus(null) })}
+            aria-invalid={!!errors.email}
+            aria-describedby="email-error"
+            required
+            autoComplete="email"
+          />
+          <span id="email-error" className="error-text">
+            {errors.email?.message}
+          </span>
+        </div>
 
-        <label htmlFor="message">Message</label>
-        <textarea
-          id="message"
-          rows="5"
-          {...register('message', { onChange: () => setStatus(null) })}
-          aria-invalid={!!errors.message}
-          aria-describedby="message-error"
-          required
-          autoComplete="off"
-        />
-        <span id="message-error" className="error-text">
-          {errors.message?.message}
-        </span>
+        <div className="flex flex-col md:col-span-2">
+          <label htmlFor="message">Message</label>
+          <textarea
+            id="message"
+            rows="5"
+            {...register('message', { onChange: () => setStatus(null) })}
+            aria-invalid={!!errors.message}
+            aria-describedby="message-error"
+            required
+            autoComplete="off"
+          />
+          <span id="message-error" className="error-text">
+            {errors.message?.message}
+          </span>
+        </div>
 
-        <Button type="submit" style={{ marginTop: 'var(--space-2)' }}>
+        <Button type="submit" className="md:col-span-2 mt-2">
           Send Message
         </Button>
         {status === 'success' && (
-          <p role="status" style={{ marginTop: 'var(--space-2)' }}>
+          <p role="status" className="md:col-span-2 mt-2">
             Message sent!
           </p>
         )}
         {status === 'error' && (
-          <p role="status" style={{ marginTop: 'var(--space-2)' }}>
+          <p role="status" className="md:col-span-2 mt-2">
             Failed to send message.
           </p>
         )}
       </motion.form>
-      <CompactEmailButton style={{ marginTop: 'var(--space-4)' }} />
+      <CompactEmailButton className="mt-4" />
     </ParallaxSection>
   );
 }

--- a/next-app/components/Hero.jsx
+++ b/next-app/components/Hero.jsx
@@ -115,11 +115,10 @@ export default function Hero() {
         🐱
       </motion.div>
       <div
-        className="mx-auto glass card"
+        className="mx-auto glass card w-full max-w-3xl lg:max-w-5xl"
         style={{
           position: 'relative',
           zIndex: 10,
-          maxWidth: '36rem',
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
@@ -169,7 +168,7 @@ export default function Hero() {
                 color: 'var(--brand-500)',
                 fontFamily: 'var(--font-sans)',
                 fontSize: 'var(--fs-1)',
-                fontWeight: 600,
+                fontWeight: 400,
                 letterSpacing: '0.1em',
                 textRendering: 'geometricPrecision',
               }}
@@ -183,7 +182,7 @@ export default function Hero() {
                   text: HERO_TAGLINE,
                   font: {
                     fontFamily: 'var(--font-sans)',
-                    fontWeight: '600',
+                    fontWeight: '400',
                     fontSize: 24,
                   },
                   color: 'var(--brand-500)',
@@ -199,7 +198,7 @@ export default function Hero() {
                   text: HERO_TAGLINE,
                   font: {
                     fontFamily: 'var(--font-sans)',
-                    fontWeight: '600',
+                    fontWeight: '400',
                     fontSize: 24,
                   },
                   color: 'var(--brand-500)',

--- a/next-app/components/ParallaxSection.jsx
+++ b/next-app/components/ParallaxSection.jsx
@@ -20,6 +20,7 @@ export default function ParallaxSection({
   children,
   priority = false,
   overlay = false,
+  maxWidth = 'max-w-3xl lg:max-w-5xl',
 }) {
   // Allow the section to render even if the author forgets an alt text.
   // When no alt is provided we fall back to treating the image as
@@ -77,8 +78,7 @@ export default function ParallaxSection({
         />
       )}
       <motion.div
-        className="relative z-20 text-center glass card"
-        style={{ maxWidth: '36rem', marginInline: 'auto' }}
+        className={`relative z-20 text-center glass card mx-auto w-full ${maxWidth}`}
         initial={{ opacity: 0, y: reduceMotion ? 0 : 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true, amount: 0.5 }}

--- a/next-app/components/SectionHeader.jsx
+++ b/next-app/components/SectionHeader.jsx
@@ -17,7 +17,7 @@ export default function SectionHeader({ title, children }) {
       </motion.h2>
       {children && (
         <motion.p
-          style={{ maxWidth: '32rem', marginInline: 'auto' }}
+          className="mx-auto max-w-3xl lg:max-w-5xl"
           variants={textVariants(reduceMotion)}
           initial="hidden"
           whileInView="show"

--- a/next-app/components/Testimonials.jsx
+++ b/next-app/components/Testimonials.jsx
@@ -72,13 +72,7 @@ export default function Testimonials() {
           {`Showing testimonial ${index + 1} of ${testimonials.length}`}
         </p>
         <div
-          style={{
-            position: 'relative',
-            marginTop: 'var(--space-6)',
-            marginInline: 'auto',
-            maxWidth: '36rem',
-            overflow: 'hidden'
-          }}
+          className="relative mt-6 mx-auto w-full max-w-3xl lg:max-w-5xl overflow-hidden"
         >
           <AnimatePresence mode="wait">
             <motion.figure
@@ -121,14 +115,7 @@ export default function Testimonials() {
             &#8594;
           </motion.button>
         </div>
-        <div
-          style={{
-            marginTop: 'var(--space-4)',
-            display: 'flex',
-            justifyContent: 'center',
-            gap: 'var(--space-2)'
-          }}
-        >
+        <div className="mt-4 flex justify-center gap-2">
           {testimonials.map((_, i) => (
             <button
               key={i}


### PR DESCRIPTION
## Summary
- widen hero, parallax, and section containers for better desktop scaling
- lighten hero ticker font weight to 400
- restructure approach steps and contact form into responsive grids
- widen testimonial carousel wrapper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4cd68577483228e73aa0b1495e29f