### PR TITLE
feat: redesign About section with responsive layout

### DIFF
--- a/next-app/__tests__/About.test.jsx
+++ b/next-app/__tests__/About.test.jsx
@@ -6,7 +6,7 @@ describe('About', () => {
   it('renders heading', () => {
     render(<About />);
     expect(
-      screen.getByRole('heading', { name: /about/i })
+      screen.getByRole('heading', { name: /our story/i })
     ).toBeInTheDocument();
   });
 });

--- a/next-app/components/About.jsx
+++ b/next-app/components/About.jsx
@@ -1,17 +1,78 @@
 "use client";
-import React from 'react';
-import ParallaxSection from './ParallaxSection';
+import { motion, useReducedMotion } from 'framer-motion';
 
 export default function About() {
+  const reduceMotion = useReducedMotion();
+
+  const fadeUp = (delay = 0) =>
+    reduceMotion
+      ? {}
+      : {
+          initial: { opacity: 0, y: 20 },
+          whileInView: { opacity: 1, y: 0 },
+          transition: { duration: 0.6, delay },
+          viewport: { once: true },
+        };
+
+  const stats = [
+    { value: '5+', label: 'years of storytelling' },
+    { value: '150+', label: 'projects delivered' },
+    { value: '24', label: 'global clients' },
+  ];
+
   return (
-    <ParallaxSection
+    <section
       id="about"
-      image="https://picsum.photos/id/1011/1600/900"
-      alt=""
-      decorative
-      overlay="linear-gradient(to bottom, color-mix(in oklab, var(--brand-500), transparent 20%), color-mix(in oklab, var(--brand-500), transparent 80%))"
-      title="About"
-      description="Learn more about our passion for capturing moments and the story behind our studio."
-    />
+      className="scroll-mt-header relative overflow-hidden bg-[#070707] text-white"
+    >
+      <div className="absolute inset-0 bg-[url('/paw-print.svg')] bg-repeat opacity-10" />
+      <div className="relative mx-auto flex min-h-[80dvh] w-full max-w-5xl flex-col items-center gap-12 px-4 py-24 md:min-h-[90dvh] md:flex-row md:gap-8">
+        <div className="md:w-3/5">
+          <motion.h2
+            className="font-sans text-4xl font-bold uppercase"
+            {...fadeUp(0)}
+          >
+            Our Story
+          </motion.h2>
+          <motion.p className="mt-6 max-w-prose" {...fadeUp(0.1)}>
+            Founded in a small island studio, The Project Archive grew from a
+            love of storytelling and a drive to capture life’s most vivid
+            moments.
+          </motion.p>
+          <motion.p className="mt-4 max-w-prose" {...fadeUp(0.2)}>
+            Today, our team blends artistry and technology to craft visuals that
+            inspire and connect.
+          </motion.p>
+          <motion.div
+            className="mt-8 flex flex-wrap gap-8"
+            {...fadeUp(0.3)}
+          >
+            {stats.map((stat) => (
+              <div key={stat.label} className="flex flex-col">
+                <span className="text-3xl font-bold">{stat.value}</span>
+                <span className="text-sm uppercase tracking-wide">
+                  {stat.label}
+                </span>
+              </div>
+            ))}
+          </motion.div>
+          <motion.a
+            href="/about"
+            className="mt-8 inline-block rounded-md bg-[#f13d00] px-6 py-3 font-semibold text-white"
+            {...fadeUp(0.4)}
+          >
+            Learn More
+          </motion.a>
+        </div>
+        <div className="flex justify-center md:w-2/5">
+          <img
+            src="/about-illustration.svg"
+            alt="Cat mascot illustration"
+            className="w-full max-w-sm"
+          />
+        </div>
+      </div>
+    </section>
   );
 }
+

--- a/next-app/public/about-illustration.svg
+++ b/next-app/public/about-illustration.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none">
+  <rect width="200" height="200" rx="20" fill="#0e0e0e"/>
+  <circle cx="100" cy="100" r="60" fill="#f13d00"/>
+  <circle cx="80" cy="90" r="10" fill="#fff"/>
+  <circle cx="120" cy="90" r="10" fill="#fff"/>
+  <path d="M70 130c20 20 40 20 60 0" stroke="#fff" stroke-width="8" stroke-linecap="round"/>
+  <path d="M40 60L70 80" stroke="#f13d00" stroke-width="8" stroke-linecap="round"/>
+  <path d="M160 60L130 80" stroke="#f13d00" stroke-width="8" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- redesign About section with black background and subtle paw-print texture
- add responsive two-column layout with stats, CTA, and illustration
- update tests for new heading and add placeholder illustration asset

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4e4e7dad08322af5453b72b1f7b42