### PR TITLE
fix: handle missing alt text in ParallaxSection

### DIFF
--- a/next-app/__tests__/ParallaxSection.test.jsx
+++ b/next-app/__tests__/ParallaxSection.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 
 beforeAll(() => {
@@ -29,5 +29,17 @@ describe('ParallaxSection', () => {
     );
     const wrapper = container.querySelector('section > div');
     expect(wrapper?.style.transform).toBe('none');
+  });
+
+  it('renders when alt text is omitted', () => {
+    render(
+      <ParallaxSection
+        id="no-alt"
+        image="https://picsum.photos/id/1011/1600/900"
+      >
+        <p>Visible content</p>
+      </ParallaxSection>
+    );
+    expect(screen.getByText('Visible content')).toBeInTheDocument();
   });
 });

--- a/next-app/components/ParallaxSection.jsx
+++ b/next-app/components/ParallaxSection.jsx
@@ -8,12 +8,12 @@ import SectionHeader from './SectionHeader';
  * Section with a parallax background image.
  * @param {string} id - Unique id used for anchor navigation.
  * @param {string} image - Background image URL.
- * @param {string} alt - Descriptive alternative text for the image.
+ * @param {string} [alt] - Descriptive alternative text for the image.
  */
 export default function ParallaxSection({
   id,
   image,
-  alt = '',
+  alt,
   decorative = false,
   title,
   description,


### PR DESCRIPTION
## Summary
- allow ParallaxSection to render when `alt` text is omitted
- test that missing `alt` doesn't hide section content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f425548c83228d59f5cf57c4d010