### PR TITLE
fix build error from client metadata export

### DIFF
--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import { motion, useReducedMotion } from 'framer-motion';
-import Hero from '../components/Hero';
-import Home from '../components/Home';
+import PageClient from '../components/PageClient';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
 
@@ -37,17 +33,5 @@ export const metadata = {
 };
 
 export default function Page() {
-  const reduceMotion = useReducedMotion();
-
-  return (
-    <motion.main
-      className="flex flex-col"
-      initial={reduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={reduceMotion ? { duration: 0 } : { duration: 0.6, ease: 'easeOut' }}
-    >
-      <Hero />
-      <Home />
-    </motion.main>
-  );
+  return <PageClient />;
 }

--- a/next-app/components/PageClient.tsx
+++ b/next-app/components/PageClient.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import Hero from './Hero';
+import Home from './Home';
+
+export default function PageClient() {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.main
+      className="flex flex-col"
+      initial={reduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={reduceMotion ? { duration: 0 } : { duration: 0.6, ease: 'easeOut' }}
+    >
+      <Hero />
+      <Home />
+    </motion.main>
+  );
+}


### PR DESCRIPTION
## Summary
- move motion homepage to a client component and keep metadata in server `page.tsx`
- fix Next.js build error caused by exporting metadata from a client component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56e5caea88322a79fa24aa39c09ee