### PR TITLE
fix: add missing typescript dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,22 @@
         "ws": "^8.17.0",
         "zod": "^3.25.76"
       },
+      "devDependencies": {
+        "@types/node": "^24.3.3",
+        "typescript": "^5.9.2"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.3.tgz",
+      "integrity": "sha512-GKBNHjoNw3Kra1Qg5UXttsY5kiWMEfoHq2TmXb+b1rcm6N7B3wTrFYIf/oSZ1xNQ+hVVijgLkiDZh7jRRsh+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/mime-db": {
@@ -47,6 +61,27 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
     "nodemailer": "^6.10.1",
     "ws": "^8.17.0",
     "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.3",
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- add TypeScript and Node type definitions to devDependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c57081c468832282a1bc25ea114e8d