### PR TITLE
Harden contact API rate limiting and captcha checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ BUSINESS_EMAIL_APP_PASSWORD=your_app_password
 
 # Optional spam protection
 RECAPTCHA_SECRET=your_recaptcha_secret
+RECAPTCHA_HOSTNAME=your_domain.com
+RECAPTCHA_ACTION=contact
+
+# Optional rate limit persistence
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
 
 # Site URLs
 SPACE_BUCKET_URL=https://example-bucket.space

--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
         "@react-three/fiber": "^8.18.0",
+        "@upstash/redis": "^1.35.3",
         "focus-trap": "^7.5.4",
         "framer-motion": "^12.23.12",
         "next": "^14.2.3",
@@ -27,6 +28,7 @@
         "@tailwindcss/postcss": "^4.1.13",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
+        "@types/node": "24.3.3",
         "autoprefixer": "^10.4.21",
         "axe-core": "^4.10.3",
         "chokidar-cli": "^3.0.0",
@@ -38,6 +40,7 @@
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "tailwindcss": "^4.1.13",
+        "typescript": "5.9.2",
         "vitest": "^3.2.4",
         "vitest-axe": "^0.1.0"
       },
@@ -1872,6 +1875,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.3.tgz",
+      "integrity": "sha512-GKBNHjoNw3Kra1Qg5UXttsY5kiWMEfoHq2TmXb+b1rcm6N7B3wTrFYIf/oSZ1xNQ+hVVijgLkiDZh7jRRsh+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
@@ -1893,6 +1906,15 @@
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.23.tgz",
       "integrity": "sha512-GPe4AsfOSpqWd3xA/0gwoKod13ChcfV67trvxaW2krUbgb9gxQjnCx8zGshzMl8LSHZlNH5gQ8LNScsDuc7nGQ==",
       "license": "MIT"
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.3",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.3.tgz",
+      "integrity": "sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -6858,6 +6880,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -6876,6 +6912,19 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
     "@react-three/fiber": "^8.18.0",
+    "@upstash/redis": "^1.35.3",
     "focus-trap": "^7.5.4",
     "framer-motion": "^12.23.12",
     "next": "^14.2.3",
@@ -36,6 +37,7 @@
     "@tailwindcss/postcss": "^4.1.13",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
+    "@types/node": "24.3.3",
     "autoprefixer": "^10.4.21",
     "axe-core": "^4.10.3",
     "chokidar-cli": "^3.0.0",
@@ -47,6 +49,7 @@
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^4.1.13",
+    "typescript": "5.9.2",
     "vitest": "^3.2.4",
     "vitest-axe": "^0.1.0"
   }


### PR DESCRIPTION
## Summary
- clean up rate limit entries and optionally persist counts in Redis
- trust `request.ip`/`x-real-ip` for throttling instead of `x-forwarded-for`
- validate reCAPTCHA hostname/action and handle invalid JSON with 400
- document env vars for reCAPTCHA and Upstash configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c57221359c832298aeb67263858bb8