### PR TITLE
Refactor button styling and section utilities

### DIFF
--- a/next-app/components/About.jsx
+++ b/next-app/components/About.jsx
@@ -1,18 +1,12 @@
 "use client";
 import { motion, useReducedMotion } from 'framer-motion';
+import ParallaxSection from './ParallaxSection';
+import SectionHeader from './SectionHeader';
+import Button from './Button';
+import { textVariants } from '../lib/animations';
 
 export default function About() {
   const reduceMotion = useReducedMotion();
-
-  const fadeUp = (delay = 0) =>
-    reduceMotion
-      ? {}
-      : {
-          initial: { opacity: 0, y: 20 },
-          whileInView: { opacity: 1, y: 0 },
-          transition: { duration: 0.6, delay },
-          viewport: { once: true },
-        };
 
   const stats = [
     { value: '5+', label: 'years of storytelling' },
@@ -21,31 +15,34 @@ export default function About() {
   ];
 
   return (
-    <section
+    <ParallaxSection
       id="about"
-      className="scroll-mt-header relative overflow-hidden bg-[#070707] text-white"
+      image="/paw-print.svg"
+      alt=""
+      decorative
+      overlay="rgba(7,7,7,0.9)"
+      maxWidth="max-w-5xl"
     >
-      <div className="absolute inset-0 bg-[url('/paw-print.svg')] bg-repeat opacity-10" />
-      <div className="relative mx-auto flex min-h-[80dvh] w-full max-w-5xl flex-col items-center gap-12 px-4 py-24 md:min-h-[90dvh] md:flex-row md:gap-8">
+      <div className="flex flex-col items-center gap-12 px-4 py-24 md:flex-row md:gap-8 text-left">
         <div className="md:w-3/5">
-          <motion.h2
-            className="font-sans text-4xl font-bold uppercase"
-            {...fadeUp(0)}
+          <SectionHeader title="Our Story">
+            Founded in a small island studio, The Project Archive grew from a love of storytelling and a drive to capture life’s most vivid moments.
+          </SectionHeader>
+          <motion.p
+            className="mt-4 max-w-prose"
+            variants={textVariants(reduceMotion)}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.5 }}
           >
-            Our Story
-          </motion.h2>
-          <motion.p className="mt-6 max-w-prose" {...fadeUp(0.1)}>
-            Founded in a small island studio, The Project Archive grew from a
-            love of storytelling and a drive to capture life’s most vivid
-            moments.
-          </motion.p>
-          <motion.p className="mt-4 max-w-prose" {...fadeUp(0.2)}>
-            Today, our team blends artistry and technology to craft visuals that
-            inspire and connect.
+            Today, our team blends artistry and technology to craft visuals that inspire and connect.
           </motion.p>
           <motion.div
             className="mt-8 flex flex-wrap gap-8"
-            {...fadeUp(0.3)}
+            variants={textVariants(reduceMotion)}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.5 }}
           >
             {stats.map((stat) => (
               <div key={stat.label} className="flex flex-col">
@@ -56,23 +53,31 @@ export default function About() {
               </div>
             ))}
           </motion.div>
-          <motion.a
-            href="/about"
-            className="mt-8 inline-block rounded-md bg-[#f13d00] px-6 py-3 font-semibold text-white"
-            {...fadeUp(0.4)}
+          <motion.div
+            className="mt-8"
+            variants={textVariants(reduceMotion)}
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.5 }}
           >
-            Learn More
-          </motion.a>
+            <Button href="/about">Learn More</Button>
+          </motion.div>
         </div>
-        <div className="flex justify-center md:w-2/5">
+        <motion.div
+          className="flex justify-center md:w-2/5"
+          variants={textVariants(reduceMotion)}
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.5 }}
+        >
           <img
             src="/about-illustration.svg"
             alt="Cat mascot illustration"
             className="w-full max-w-sm"
           />
-        </div>
+        </motion.div>
       </div>
-    </section>
+    </ParallaxSection>
   );
 }
 

--- a/next-app/components/Button.jsx
+++ b/next-app/components/Button.jsx
@@ -1,28 +1,31 @@
 'use client';
 import { motion, useReducedMotion } from 'framer-motion';
+import clsx from 'clsx';
+
+// Centralized button style variants for reuse across components
+export const buttonVariants = {
+  primary: 'button button--primary',
+  danger: 'button button--danger',
+  secondary: 'button button--secondary',
+  brand3d: 'button button--3d',
+};
 
 export default function Button({
   href,
   variant = 'primary',
-  className = '',
+  className,
   style,
   children,
   ...props
 }) {
   const reduceMotion = useReducedMotion();
   const Component = href ? motion.a : motion.button;
-  const variants = {
-    primary: 'button button--primary',
-    danger: 'button button--danger',
-    secondary: 'button button--secondary',
-    brand3d: 'button button--3d',
-  };
-  const variantClass = variants[variant] ?? 'button';
+  const variantClass = buttonVariants[variant] ?? 'button';
   return (
     <Component
       href={href}
       type={href ? undefined : 'button'}
-      className={`${variantClass} ${className}`.trim()}
+      className={clsx(variantClass, className)}
       whileHover={reduceMotion ? undefined : { scale: 1.05 }}
       whileTap={reduceMotion ? undefined : { scale: 0.95 }}
       style={style}

--- a/next-app/components/ServicesStack.tsx
+++ b/next-app/components/ServicesStack.tsx
@@ -3,6 +3,7 @@
 import { motion, useReducedMotion, useMotionValue, useTransform } from 'framer-motion';
 import { useCallback, type CSSProperties, type MouseEvent } from 'react';
 import Button from './Button';
+import SectionHeader from './SectionHeader';
 
 type ServiceItem = {
   title: string;
@@ -16,20 +17,26 @@ interface ServicesStackProps {
   items?: ServiceItem[];
 }
 
-const containerVariants = {
+const containerVariants = (reduce: boolean) => ({
   hidden: { opacity: 0 },
   show: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.15,
+      staggerChildren: reduce ? 0 : 0.15,
     },
   },
-};
+});
 
-const cardVariants = {
-  hidden: { opacity: 0, y: 24 },
-  show: { opacity: 1, y: 0 },
-};
+const cardVariants = (reduce: boolean) => ({
+  hidden: { opacity: 0, y: reduce ? 0 : 24 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: reduce ? 0 : 0.4 },
+  },
+});
+
+const cardClass = 'glass border border-white/20 rounded-2xl p-6 shadow-lg';
 
 export default function ServicesStack({ items = [] }: ServicesStackProps) {
   const reduceMotion = useReducedMotion();
@@ -60,13 +67,10 @@ export default function ServicesStack({ items = [] }: ServicesStackProps) {
   if (reduceMotion) {
     return (
       <section id="services" className="mx-auto max-w-5xl px-4 py-16">
-        <h2 className="text-2xl md:text-3xl font-semibold">Services</h2>
+        <SectionHeader title="Services" />
         <div className="mt-8 space-y-6">
           {items.map((item, i) => (
-            <article
-              key={i}
-              className="bg-black/40 backdrop-blur-md border border-white/20 rounded-2xl p-6 shadow-lg"
-            >
+            <article key={i} className={cardClass}>
               <h3 className="flex items-center text-lg font-semibold">
                 {item.icon && (
                   <span className="mr-2 text-xl" aria-hidden="true">
@@ -95,12 +99,12 @@ export default function ServicesStack({ items = [] }: ServicesStackProps) {
     <motion.section
       id="services"
       className="mx-auto max-w-5xl px-4 py-16"
-      variants={containerVariants}
+      variants={containerVariants(reduceMotion)}
       initial="hidden"
       whileInView="show"
       viewport={{ once: true, amount: 0.2 }}
     >
-      <h2 className="text-2xl md:text-3xl font-semibold">Services</h2>
+      <SectionHeader title="Services" />
       <motion.div
         className="mt-8 space-y-6 md:space-y-0 md:relative md:perspective-[1000px]"
         onMouseMove={handleMouseMove}
@@ -110,11 +114,8 @@ export default function ServicesStack({ items = [] }: ServicesStackProps) {
         {items.map((item, i) => (
           <motion.article
             key={i}
-            variants={cardVariants}
-            className={
-              'bg-black/40 backdrop-blur-md border border-white/20 rounded-2xl p-6 shadow-lg ' +
-              'md:translate-x-[var(--offset-x)] md:translate-y-[var(--offset-y)]'
-            }
+            variants={cardVariants(reduceMotion)}
+            className={`${cardClass} md:translate-x-[var(--offset-x)] md:translate-y-[var(--offset-y)]`}
             style={{
               '--offset-x': `${i * 32}px`,
               '--offset-y': `${i * -24}px`,

--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
         "@react-three/fiber": "^8.18.0",
+        "clsx": "^2.1.0",
         "focus-trap": "^7.5.4",
         "framer-motion": "^12.23.12",
         "next": "^14.2.3",
@@ -27,6 +28,7 @@
         "@tailwindcss/postcss": "^4.1.13",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
+        "@types/node": "24.3.3",
         "autoprefixer": "^10.4.21",
         "axe-core": "^4.10.3",
         "chokidar-cli": "^3.0.0",
@@ -38,6 +40,7 @@
         "postcss": "^8.5.6",
         "prettier": "^3.6.2",
         "tailwindcss": "^4.1.13",
+        "typescript": "5.9.2",
         "vitest": "^3.2.4",
         "vitest-axe": "^0.1.0"
       },
@@ -1872,6 +1875,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.3.tgz",
+      "integrity": "sha512-GKBNHjoNw3Kra1Qg5UXttsY5kiWMEfoHq2TmXb+b1rcm6N7B3wTrFYIf/oSZ1xNQ+hVVijgLkiDZh7jRRsh+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
@@ -2722,6 +2735,15 @@
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
         "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -6858,6 +6880,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -6876,6 +6912,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -29,13 +29,15 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.62.0",
     "three": "^0.151.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "clsx": "^2.1.0"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^14.2.32",
     "@tailwindcss/postcss": "^4.1.13",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
+    "@types/node": "24.3.3",
     "autoprefixer": "^10.4.21",
     "axe-core": "^4.10.3",
     "chokidar-cli": "^3.0.0",
@@ -47,6 +49,7 @@
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "tailwindcss": "^4.1.13",
+    "typescript": "5.9.2",
     "vitest": "^3.2.4",
     "vitest-axe": "^0.1.0"
   }


### PR DESCRIPTION
## Summary
- centralize button variants with `clsx` and export for reuse
- refactor Our Story section to use shared components and motion helpers
- unify Services section styling with SectionHeader and shared card utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c573635ef08322909dea3f6d598b96