### PR TITLE
Remove invalid export from contact route

### DIFF
--- a/next-app/__tests__/api/contact.test.js
+++ b/next-app/__tests__/api/contact.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { POST, _clearRateLimit } from '../../app/api/contact/route.js';
 import nodemailer from 'nodemailer';
+
+let POST;
 
 vi.mock('nodemailer', () => ({
   default: {
@@ -11,12 +12,13 @@ vi.mock('nodemailer', () => ({
 }));
 
 describe('POST /api/contact', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     process.env.BUSINESS_EMAIL = 'biz@example.com';
     process.env.BUSINESS_EMAIL_APP_PASSWORD = 'app-pass';
     delete process.env.RECAPTCHA_SECRET;
-    _clearRateLimit();
+    vi.resetModules();
+    ({ POST } = await import('../../app/api/contact/route.js'));
   });
 
   it('sends an email on success', async () => {

--- a/next-app/app/api/contact/route.js
+++ b/next-app/app/api/contact/route.js
@@ -50,10 +50,6 @@ async function isRateLimited(ip) {
   return false;
 }
 
-export function _clearRateLimit() {
-  rateLimitMap.clear();
-}
-
 const schema = z.object({
   name: z.string().min(1),
   email: z.string().email(),


### PR DESCRIPTION
## Summary
- Remove non-route `_clearRateLimit` export from Next.js contact API route
- Dynamically import contact API route in tests instead of relying on removed export

## Testing
- `npm test`
- `npm --prefix next-app run build` *(fails: Property 'style' is missing in type in components/Hero.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c57abf48c88322b40e46363eaba46a