### PR TITLE
feat: add supabase login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ To forward contact form submissions to your Google Business inbox:
 
      The endpoint applies basic rate limiting (5 requests per minute per IP) to prevent abuse.
 
+## User Authentication
+
+The site includes a basic Supabase-powered login page at `/login`. Set
+`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` in your `.env`
+to enable email and password authentication.
+
 ## Development
 
 Install dependencies and start the development server:

--- a/next-app/__tests__/Login.test.jsx
+++ b/next-app/__tests__/Login.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import LoginPage from '../app/login/page.jsx';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('../lib/supabaseClient.js', () => ({
+  supabaseClient: { auth: { signInWithPassword: vi.fn() } },
+}));
+
+describe('Login page', () => {
+  it('renders login form', () => {
+    render(<LoginPage />);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+});

--- a/next-app/app/login/page.jsx
+++ b/next-app/app/login/page.jsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+import { supabaseClient } from '../../lib/supabaseClient.js';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!supabaseClient) {
+      setMessage('Supabase not configured');
+      return;
+    }
+    const { error } = await supabaseClient.auth.signInWithPassword({
+      email,
+      password,
+    });
+    setMessage(error ? error.message : 'Signed in');
+  };
+
+  return (
+    <main className="container">
+      <h1>Sign In</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit">Sign In</button>
+      </form>
+      {message && <p>{message}</p>}
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add basic Supabase email/password login page
- document Supabase login setup in README
- test login form rendering

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68c58327224c832284a382af7ac427d5