### PR TITLE
Improve robots directives for search engines

### DIFF
--- a/next-app/__tests__/RobotsDomain.test.js
+++ b/next-app/__tests__/RobotsDomain.test.js
@@ -12,4 +12,11 @@ describe('robots sitemap URL', () => {
     const result = robots();
     expect(result.sitemap).toBe(`${domain}/sitemap.xml`);
   });
+
+  it('disallows non-public routes', () => {
+    const result = robots();
+    const disallowed = result.rules[0].disallow;
+    expect(disallowed).toContain('/api');
+    expect(disallowed).toContain('/coming-soon');
+  });
 });

--- a/next-app/app/robots.js
+++ b/next-app/app/robots.js
@@ -3,10 +3,14 @@ export default function robots() {
   // Fall back to localhost if NEXT_PUBLIC_SITE_URL is missing
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-    },
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        // Prevent indexing of application endpoints and unfinished pages
+        disallow: ['/api', '/coming-soon', '/404', '/500'],
+      },
+    ],
     sitemap: `${siteUrl}/sitemap.xml`,
   };
 }

--- a/next-app/vitest.setup.js
+++ b/next-app/vitest.setup.js
@@ -30,6 +30,11 @@ vi.mock('next/navigation', () => ({
   usePathname: () => '/',
 }));
 
+vi.mock('next-auth/react', () => ({
+  SessionProvider: ({ children }) => React.createElement(React.Fragment, null, children),
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
 class MockIntersectionObserver {
   constructor() {}
   observe() {}


### PR DESCRIPTION
## Summary
- expand robots directives to block API endpoints and temporary pages
- test robots generation and mock next-auth to avoid network calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a7e23f9c83229b2cae667de9758a