### PR TITLE
Add uptime monitoring script

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,18 @@ When deployed to platforms like DigitalOcean App Platform, the buildpacks instal
 - **DDoS Protection** – Reroutes malicious traffic to keep the site accessible.
 - **Level 1 PCI Compliance** – Meets the highest global standard for secure online payments.
 
+## Uptime Monitoring
+
+Use the `scripts/uptime-monitor.js` script to check site availability and verify basic security headers:
+
+```bash
+node scripts/uptime-monitor.js https://example.com
+# or use the SITE_URL environment variable
+SITE_URL=https://example.com npm run uptime
+```
+
+The script issues a `HEAD` request (falling back to `GET` if necessary), reports the HTTP status and response time, and warns about missing security headers.
+
 ## Accessibility
 
 Animated components respect the user's `prefers-reduced-motion` setting, and the lightbox dialog traps focus for keyboard users.

--- a/next-app/package-lock.json
+++ b/next-app/package-lock.json
@@ -19,7 +19,7 @@
         "next": "^14.2.3",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "nodemailer": "^7.0.6",
+        "nodemailer": "^6.10.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.62.0",
@@ -5621,9 +5621,9 @@
       "dev": true
     },
     "node_modules/nodemailer": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.6.tgz",
-      "integrity": "sha512-F44uVzgwo49xboqbFgBGkRaiMgtoBrBEWCVincJPK9+S9Adkzt/wXCLKbf7dxucmxfTI5gHGB+bEmdyzN6QKjw==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/next-app/package.json
+++ b/next-app/package.json
@@ -28,7 +28,7 @@
     "next": "^14.2.3",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "nodemailer": "^7.0.6",
+    "nodemailer": "^6.10.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.62.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "npm --prefix next-app run test",
     "lint": "npm --prefix next-app run lint",
     "format": "npm --prefix next-app run format",
+    "uptime": "node scripts/uptime-monitor.js",
     "check": "npm run lint && npm test"
   },
   "engines": {

--- a/scripts/uptime-monitor.js
+++ b/scripts/uptime-monitor.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { performance } from 'node:perf_hooks';
+
+function usage() {
+  console.error('Usage: node scripts/uptime-monitor.js <url>');
+}
+
+const urlArg = process.argv[2];
+const url = urlArg || process.env.SITE_URL;
+if (!url) {
+  usage();
+  process.exit(1);
+}
+
+const start = performance.now();
+try {
+  let res = await fetch(url, { method: 'HEAD' });
+  // fallback to GET if HEAD is not allowed
+  if (res.status === 405) {
+    res = await fetch(url, { method: 'GET' });
+  }
+  const duration = Math.round(performance.now() - start);
+  console.log(`${url} -> ${res.status} in ${duration}ms`);
+  const requiredHeaders = [
+    'strict-transport-security',
+    'content-security-policy',
+    'x-frame-options',
+    'x-content-type-options',
+  ];
+  const missing = requiredHeaders.filter(h => !res.headers.has(h));
+  if (missing.length) {
+    console.warn(`Missing security headers: ${missing.join(', ')}`);
+  }
+  process.exit(res.ok ? 0 : 1);
+} catch (err) {
+  console.error(`Request failed: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `uptime-monitor` script to check availability and security headers
- document usage and add npm `uptime` script
- align `nodemailer` with `next-auth` peer dependency

## Testing
- `npm --prefix next-app install`
- `npm run lint`
- `npm test` *(fails: 1 unhandled error)*
- `node scripts/uptime-monitor.js https://example.com` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a82f63988322b9f3d6bb3fb83dd4