### PR TITLE
Handle invalid NEXTAUTH_URL and add offline uptime test

### DIFF
--- a/next-app/__tests__/nextauth-url.test.js
+++ b/next-app/__tests__/nextauth-url.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+
+describe('NextAuth configuration', () => {
+  it('defaults NEXTAUTH_URL when invalid', async () => {
+    process.env.NEXTAUTH_URL = '::::';
+    process.env.GITHUB_ID = 'id';
+    process.env.GITHUB_SECRET = 'secret';
+    process.env.NEXTAUTH_SECRET = 'secret';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const mod = await import('../app/api/auth/[...nextauth]/route.js?c=' + Date.now());
+    expect(typeof mod.GET).toBe('function');
+    expect(process.env.NEXTAUTH_URL).toBe('http://localhost:3000');
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[Auth] NEXTAUTH_URL is invalid, defaulting to http://localhost:3000',
+    );
+    warnSpy.mockRestore();
+    delete process.env.NEXTAUTH_URL;
+    delete process.env.GITHUB_ID;
+    delete process.env.GITHUB_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+  });
+});

--- a/next-app/__tests__/uptime-monitor.test.js
+++ b/next-app/__tests__/uptime-monitor.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import http from 'http';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function runScript(url) {
+  const script = resolve(__dirname, '../../scripts/uptime-monitor.js');
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [script, url]);
+    let output = '';
+    child.stdout.on('data', (d) => (output += d));
+    child.stderr.on('data', (d) => (output += d));
+    child.on('close', (code) => resolve({ code, output }));
+  });
+}
+
+describe('uptime monitor script', () => {
+  it('succeeds against a local server', async () => {
+    const server = http
+      .createServer((req, res) => {
+        res.writeHead(200, {
+          'strict-transport-security': 'max-age=31536000',
+          'content-security-policy': "default-src 'self'",
+          'x-frame-options': 'DENY',
+          'x-content-type-options': 'nosniff',
+        });
+        res.end('ok');
+      })
+      .listen(0);
+    await new Promise((r) => server.once('listening', r));
+    const url = `http://localhost:${server.address().port}`;
+    const { code, output } = await runScript(url);
+    expect(code).toBe(0);
+    expect(output).toMatch(new RegExp(`${url} -> 200`));
+    await new Promise((r) => server.close(r));
+  });
+});

--- a/next-app/app/api/auth/[...nextauth]/route.js
+++ b/next-app/app/api/auth/[...nextauth]/route.js
@@ -1,6 +1,21 @@
 import NextAuth from 'next-auth';
 import GithubProvider from 'next-auth/providers/github';
 
+let baseUrl = process.env.NEXTAUTH_URL;
+if (baseUrl) {
+  try {
+    new URL(baseUrl);
+  } catch {
+    console.warn(
+      '[Auth] NEXTAUTH_URL is invalid, defaulting to http://localhost:3000',
+    );
+    baseUrl = 'http://localhost:3000';
+  }
+} else {
+  baseUrl = 'http://localhost:3000';
+}
+process.env.NEXTAUTH_URL = baseUrl;
+
 const handler = NextAuth({
   providers: [
     GithubProvider({


### PR DESCRIPTION
## Summary
- default NEXTAUTH_URL to http://localhost:3000 when missing or invalid
- add coverage for NextAuth config
- test uptime monitor against a local server to avoid network dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5aa6d7ce88322b123f7f63aa0d4f6