### PR TITLE
Simplify CI with combined lint and test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,4 @@ jobs:
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm --prefix next-app ci
-      - run: npm run lint
-      - run: npm test
+      - run: npm run check

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Update `ALLOWED_ORIGINS`, `SPACE_BUCKET_URL`, `SITE_URL`,
 ## Continuous Integration
 
 A GitHub Actions workflow (`.github/workflows/ci.yml`) runs linting and tests
-on pushes and pull requests to ensure code quality.
+via `npm run check` on pushes and pull requests to ensure code quality.
 
 ## Maintenance mode
 


### PR DESCRIPTION
## Summary
- streamline CI by using `npm run check` for lint and unit tests
- document CI workflow running `npm run check`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c5aa814a788322bd697d995b29301d